### PR TITLE
Make default security group optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ resource "aws_iam_role" "default" {
 }
 
 resource "aws_security_group" "default" {
-  count       = "${var.create_security_group}"
+  count       = "${var.create_default_security_group}"
   name        = "${module.label.id}"
   vpc_id      = "${var.vpc_id}"
   description = "Instance default security group (only egress access is allowed)"
@@ -89,7 +89,7 @@ resource "aws_instance" "default" {
   user_data = "${data.template_file.user_data.rendered}"
 
   vpc_security_group_ids = [
-    "${compact(concat(list(var.create_security_group ? join("", aws_security_group.default.*.id) : ""), var.security_groups))}",
+    "${compact(concat(list(var.create_default_security_group ? join("", aws_security_group.default.*.id) : ""), var.security_groups))}",
   ]
 
   iam_instance_profile        = "${aws_iam_instance_profile.default.name}"

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,7 @@ resource "aws_iam_role" "default" {
 }
 
 resource "aws_security_group" "default" {
+  count       = "${var.create_security_group}"
   name        = "${module.label.id}"
   vpc_id      = "${var.vpc_id}"
   description = "Instance default security group (only egress access is allowed)"
@@ -88,7 +89,7 @@ resource "aws_instance" "default" {
   user_data = "${data.template_file.user_data.rendered}"
 
   vpc_security_group_ids = [
-    "${compact(concat(list(aws_security_group.default.id), var.security_groups))}",
+    "${compact(concat(list(var.create_security_group ? join("", aws_security_group.default.*.id) : ""), var.security_groups))}",
   ]
 
   iam_instance_profile        = "${aws_iam_instance_profile.default.name}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,8 +22,8 @@ output "ssh_key_pair" {
   value = "${var.ssh_key_pair}"
 }
 
-output "security_group_id" {
-  value = "${var.create_security_group ? join("", aws_security_group.default.*.id)  : ""}"
+output "security_group_ids" {
+  value = "${compact(concat(list(var.create_default_security_group ? join("", aws_security_group.default.*.id) : ""), var.security_groups))}"
 }
 
 output "role" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,7 +23,7 @@ output "ssh_key_pair" {
 }
 
 output "security_group_id" {
-  value = "${aws_security_group.default.id}"
+  value = "${var.create_security_group ? join("", aws_security_group.default.*.id)  : ""}"
 }
 
 output "role" {

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,7 @@ variable "vpc_id" {}
 
 variable "security_groups" {
   type = "list"
+  default = []
 }
 
 variable "subnets" {
@@ -102,4 +103,9 @@ variable "metric_threshold" {
 
 variable "default_alarm_action" {
   default = "action/actions/AWS_EC2.InstanceId.Reboot/1.0"
+}
+
+variable "create_security_group" {
+  description = "Should be created a security group for new instance"
+  default = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -106,6 +106,6 @@ variable "default_alarm_action" {
 }
 
 variable "create_security_group" {
-  description = "Should be created a security group for new instance"
+  description = "Create default Security Group with Egress traffic allowed only"
   default = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -105,7 +105,7 @@ variable "default_alarm_action" {
   default = "action/actions/AWS_EC2.InstanceId.Reboot/1.0"
 }
 
-variable "create_security_group" {
+variable "create_default_security_group" {
   description = "Create default Security Group with Egress traffic allowed only"
   default = true
 }


### PR DESCRIPTION
## What
* Make default security group optional

## Why
* Some times we cannot create security group because AWS limits exceeded

## Plan
![image](https://user-images.githubusercontent.com/1134449/30749805-260f8fe0-9fbd-11e7-8261-971e810ec7c2.png)
