### PR TITLE
Utilize TF `locals` feature in order to implement instance switch option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 # Module directory
 .terraform/
-
+.idea

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ module "label" {
 }
 
 locals {
-  instance_count = "${var.instance_enabled == true ? 1 : 0}"
+  instance_count = "${var.instance_enabled ? 1 : 0}"
 }
 
 resource "aws_iam_instance_profile" "default" {
@@ -117,7 +117,7 @@ resource "aws_instance" "default" {
 }
 
 resource "aws_eip" "default" {
-  count    = "${var.associate_public_ip_address && local.instance_count ? 1 : 0}"
+  count    = "${var.associate_public_ip_address && var.instance_enabled ? 1 : 0}"
   instance = "${aws_instance.default.id}"
   vpc      = true
 }
@@ -168,7 +168,7 @@ resource "aws_cloudwatch_metric_alarm" "default" {
 }
 
 resource "null_resource" "eip" {
-  count = "${var.associate_public_ip_address && local.instance_count ? 1 : 0}"
+  count = "${var.associate_public_ip_address && var.instance_enabled ? 1 : 0}"
 
   triggers {
     public_dns = "ec2-${replace(aws_eip.default.public_ip, ".", "-")}.${data.aws_region.default.name == "us-east-1" ? "compute-1" : "${data.aws_region.default.name}.compute"}.amazonaws.com"

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,8 @@ module "label" {
 }
 
 locals {
-  instance_count = "${var.instance_enabled ? 1 : 0}"
+  instance_count        = "${var.instance_enabled ? 1 : 0}"
+  create_security_group = "${var.create_default_security_group ? 1 : 0}"
 }
 
 resource "aws_iam_instance_profile" "default" {
@@ -47,7 +48,7 @@ resource "aws_iam_role" "default" {
 }
 
 resource "aws_security_group" "default" {
-  count       = "${var.create_default_security_group}"
+  count       = "${local.create_security_group}"
   name        = "${module.label.id}"
   vpc_id      = "${var.vpc_id}"
   description = "Instance default security group (only egress access is allowed)"

--- a/main.tf
+++ b/main.tf
@@ -29,8 +29,8 @@ module "label" {
 }
 
 locals {
-  instance_count        = "${var.instance_enabled ? 1 : 0}"
-  create_security_group = "${var.create_default_security_group ? 1 : 0}"
+  instance_count       = "${var.instance_enabled ? 1 : 0}"
+  security_group_count = "${var.create_default_security_group ? 1 : 0}"
 }
 
 resource "aws_iam_instance_profile" "default" {
@@ -48,7 +48,7 @@ resource "aws_iam_role" "default" {
 }
 
 resource "aws_security_group" "default" {
-  count       = "${local.create_security_group}"
+  count       = "${local.security_group_count}"
   name        = "${module.label.id}"
   vpc_id      = "${var.vpc_id}"
   description = "Instance default security group (only egress access is allowed)"


### PR DESCRIPTION
## What
* Utilize TF `locals` feature in order to implement instance switch option

## Why
* We shouldn't use `boolean` value with `count` attribute. TF interpolates `"true"/"false"` strings as booleans, but can't interpolate `string` -> `boolean` -> `int`

## Plan
![image](https://user-images.githubusercontent.com/1134449/31124714-48dc065e-a84e-11e7-8206-13a9de628861.png)
