### PR TITLE
Exclude Ansible provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,6 @@ Include this repository as a module in your existing terraform code:
 ```terraform
 module "admin_tier" {
   source                      = "git::https://github.com/cloudposse/terraform-aws-ec2-instance.git?ref=master"
-  ansible_playbook            = "${var.ansible_playbook}"
-  ansible_arguments           = "${var.ansible_arguments}"
-  ansible_envs                = "${var.ansible_envs}"
-  ansible_dry_run             = "${var.ansible_dry_run}"
   ssh_key_pair                = "${var.ssh_key_pair}"
   github_api_token            = "${var.github_api_token}"
   github_organization         = "${var.github_organization}"
@@ -36,7 +32,6 @@ This module depends on these modules:
 
 * [terraform-null-label](https://github.com/cloudposse/terraform-null-label)
 * [tf_github_authorized_keys](https://github.com/cloudposse/tf_github_authorized_keys)
-* [terraform-null-ansible](https://github.com/cloudposse/terraform-null-ansible)
 
 It is necessary to run `terraform get` to download those modules.
 
@@ -64,10 +59,6 @@ resource "aws_ami_from_instance" "example" {
 | `github_api_token`              |                       ``                       | GitHub API token                                                                         |   Yes    |
 | `github_organization`           |                       ``                       | GitHub organization name                                                                 |   Yes    |
 | `github_team`                   |                       ``                       | GitHub team                                                                              |   Yes    |
-| `ansible_playbook`              |                       ``                       | Path to the playbook - required for `tf_ansible` (e.g. `./admin_tier.yml`)               |   Yes    |
-| `ansible_arguments`             |                       []                       | List of ansible arguments (e.g. `["--user=ubuntu"]`)                                     |    No    |
-| `ansible_envs`                  |                       []                       | List of ansible envs (e.g. `["ansible_ssh_pass=${var.ansible_ssh_password}"]`)           |    No    |
-| `ansible_dry_run`               |                    `false`                     | The Ansible run without changes                                                          |    No    |
 | `instance_type`                 |                   `t2.micro`                   | The type of the creating instance (e.g. `t2.micro`)                                      |    No    |
 | `vpc_id`                        |                       ``                       | The id of the VPC that the creating instance security group belongs to                   |   Yes    |
 | `security_groups`               |                       []                       | List of Security Group IDs allowed to connect to creating instance                       |   Yes    |

--- a/main.tf
+++ b/main.tf
@@ -123,15 +123,6 @@ resource "aws_eip" "default" {
   vpc      = true
 }
 
-# Apply the provisioner module for this resource
-module "ansible" {
-  source    = "git::https://github.com/cloudposse/terraform-null-ansible.git?ref=tags/0.3.9"
-  arguments = "${var.ansible_arguments}"
-  envs      = "${compact(concat(var.ansible_envs, list("host=${var.associate_public_ip_address ? join("", aws_eip.default.*.public_ip) : join("", aws_instance.default.*.private_ip)}")))}"
-  playbook  = "${var.ansible_playbook}"
-  dry_run   = "${var.ansible_dry_run}"
-}
-
 # Restart dead or hung instance
 data "aws_region" "default" {
   current = true

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,3 @@
-# Using tf_ansible module
-
 data "aws_iam_policy_document" "default" {
   statement {
     sid = ""

--- a/variables.tf
+++ b/variables.tf
@@ -103,10 +103,10 @@ variable "default_alarm_action" {
 
 variable "create_default_security_group" {
   description = "Create default Security Group with Egress traffic allowed only"
-  default     = true
+  default     = "true"
 }
 
 variable "instance_enabled" {
   description = "Flag for creating an instance. Set to false if it is necessary to skip instance creation"
-  default     = true
+  default     = "true"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,26 +6,8 @@ variable "github_organization" {}
 
 variable "github_team" {}
 
-variable "ansible_playbook" {
-  default = ""
-}
-
 variable "associate_public_ip_address" {
   default = true
-}
-
-variable "ansible_arguments" {
-  type    = "list"
-  default = []
-}
-
-variable "ansible_envs" {
-  type    = "list"
-  default = []
-}
-
-variable "ansible_dry_run" {
-  default = false
 }
 
 variable "instance_type" {


### PR DESCRIPTION
## What
* Exclude Ansible provisioner

## Why
* It is better to have Ansible separately from TF, because Ansible has own provisioning approach (inventory)

## Plan
![image](https://user-images.githubusercontent.com/1134449/32381897-895e0eda-c0bc-11e7-8362-d9c6ce9c9ad5.png)
