### PR TITLE
Add additional ENIs with EIPs capability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+addons:
+  apt:
+    packages:
+      - git
+      - make
+      - curl
+
+install:
+  - make init
+
+script:
+  - make terraform:install
+  - make terraform:get-plugins
+  - make terraform:get-modules
+  - make terraform:lint
+  - make terraform:validate

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+SHELL := /bin/bash
+
+-include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+
+lint:
+	$(SELF) terraform:install terraform:get-modules terraform:get-plugins terraform:lint terraform:validate

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# terraform-aws-ec2-instance
+# terraform-aws-ec2-instance [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-ec2-instance.svg)](https://travis-ci.org/cloudposse/terraform-aws-ec2-instance)
 
 Terraform Module for providing a server capable of running admin tasks. Use `terraform-aws-ec2-instance` to create and manage an admin instance.
 
@@ -64,28 +64,32 @@ resource "aws_ami_from_instance" "example" {
 | `security_groups`               |                       []                       | List of Security Group IDs allowed to connect to creating instance                       |   Yes    |
 | `subnets`                       |                       []                       | List of VPC Subnet IDs creating instance launched in                                     |   Yes    |
 | `associate_public_ip_address`   |                     `true`                     | Associate a public ip address with the creating instance. Boolean value                  |    No    |
-| `comparison_operator`           |        `GreaterThanOrEqualToThreshold`         | Arithmetic operation to use when comparing the specified Statistic and Threshold         |   Yes    |
-| `metric_name`                   |          `StatusCheckFailed_Instance`          | Name for the alarm's associated metric                                                   |   Yes    |
-| `evaluation_periods`            |                      `5`                       | Number of periods over which data is compared to the specified threshold                 |   Yes    |
-| `metric_namespace`              |                   `AWS/EC2`                    | Namespace for the alarm's associated metric                                              |   Yes    |
-| `applying_period`               |                      `60`                      | Period in seconds over which the specified statistic is applied                          |   Yes    |
-| `statistic_level`               |                   `Maximum`                    | Statistic to apply to the alarm's associated metric                                      |   Yes    |
-| `metric_threshold`              |                      `1`                       | Value against which the specified statistic is compared                                  |   Yes    |
-| `default_alarm_action`          | `action/actions/AWS_EC2.InstanceId.Reboot/1.0` | String of action to execute when this alarm transitions into an ALARM state              |   Yes    |
+| `comparison_operator`           |        `GreaterThanOrEqualToThreshold`         | Arithmetic operation to use when comparing the specified Statistic and Threshold         |    No    |
+| `metric_name`                   |          `StatusCheckFailed_Instance`          | Name for the alarm's associated metric                                                   |    No    |
+| `evaluation_periods`            |                      `5`                       | Number of periods over which data is compared to the specified threshold                 |    No    |
+| `metric_namespace`              |                   `AWS/EC2`                    | Namespace for the alarm's associated metric                                              |    No    |
+| `applying_period`               |                      `60`                      | Period in seconds over which the specified statistic is applied                          |    No    |
+| `statistic_level`               |                   `Maximum`                    | Statistic to apply to the alarm's associated metric                                      |    No    |
+| `metric_threshold`              |                      `1`                       | Value against which the specified statistic is compared                                  |    No    |
+| `default_alarm_action`          | `action/actions/AWS_EC2.InstanceId.Reboot/1.0` | String of action to execute when this alarm transitions into an ALARM state              |    No    |
+| `additional_ips_count`          |                      `0`                       | Count of additional EIPs                                                                 |    No    |
+
 
 ## Outputs
 
-| Name                | Description                                                        |
-|:--------------------|:-------------------------------------------------------------------|
-| `id`                | Disambiguated ID                                                   |
-| `private_dns`       | Normalized name                                                    |
-| `private_ip`        | Normalized namespace                                               |
-| `public_ip`         | Public IP of instance (or EIP )                                    |
-| `public_dns`        | Public DNS of instance (or DNS of EIP)                             |
-| `ssh_key_pair`      | Name of used AWS SSH key                                           |
-| `security_group_id` | ID on the new AWS Security Group associated with creating instance |
-| `role`              | Name of AWS IAM Role associated with creating instance             |
-| `alarm`             | CloudWatch Alarm ID                                                |
+| Name                 | Description                                                        |
+|:---------------------|:-------------------------------------------------------------------|
+| `id`                 | Disambiguated ID                                                   |
+| `private_dns`        | Normalized name                                                    |
+| `private_ip`         | Normalized namespace                                               |
+| `public_ip`          | Public IP of instance (or EIP )                                    |
+| `public_dns`         | Public DNS of instance (or DNS of EIP)                             |
+| `ssh_key_pair`       | Name of used AWS SSH key                                           |
+| `security_group_id`  | ID on the new AWS Security Group associated with creating instance |
+| `role`               | Name of AWS IAM Role associated with creating instance             |
+| `alarm`              | CloudWatch Alarm ID                                                |
+| `additional_eni_ids` | Map of ENI with EIP                                                |
+
 
 ## References
 * Thanks to https://github.com/cloudposse/tf_bastion for the inspiration

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ module "admin_tier" {
   instance_type               = "${var.instance_type}"
   vpc_id                      = "${var.vpc_id}"
   security_groups             = ["${var.security_groups}"]
-  subnets                     = ["${var.subnets}"]
+  subnet                      = ["${var.subnet}"]
   associate_public_ip_address = "${var.associate_public_ip_address}"
   name                        = "${var.name}"
   namespace                   = "${var.namespace}"
@@ -62,7 +62,7 @@ resource "aws_ami_from_instance" "example" {
 | `instance_type`                 |                   `t2.micro`                   | The type of the creating instance (e.g. `t2.micro`)                                      |    No    |
 | `vpc_id`                        |                       ``                       | The id of the VPC that the creating instance security group belongs to                   |   Yes    |
 | `security_groups`               |                       []                       | List of Security Group IDs allowed to connect to creating instance                       |   Yes    |
-| `subnets`                       |                       []                       | List of VPC Subnet IDs creating instance launched in                                     |   Yes    |
+| `subnet`                        |                       ``                       | VPC Subnet ID creating instance launched in                                              |   Yes    |
 | `associate_public_ip_address`   |                     `true`                     | Associate a public ip address with the creating instance. Boolean value                  |    No    |
 | `comparison_operator`           |        `GreaterThanOrEqualToThreshold`         | Arithmetic operation to use when comparing the specified Statistic and Threshold         |    No    |
 | `metric_name`                   |          `StatusCheckFailed_Instance`          | Name for the alarm's associated metric                                                   |    No    |

--- a/eni.tf
+++ b/eni.tf
@@ -1,6 +1,10 @@
-resource "aws_network_interface" "default" {
-  count     = "${var.additional_ips_count}"
-  subnet_id = "${var.subnets[0]}"
+locals {
+  additional_ips_count = "${var.associate_public_ip_address && var.instance_enabled && var.additional_ips_count != "0" ? var.additional_ips_count : 0}"
+}
+
+resource "aws_network_interface" "additional" {
+  count     = "${local.additional_ips_count}"
+  subnet_id = "${var.subnet}"
 
   security_groups = [
     "${compact(concat(list(var.create_default_security_group ? join("", aws_security_group.default.*.id) : ""), var.security_groups))}",
@@ -13,15 +17,15 @@ resource "aws_network_interface" "default" {
   }
 }
 
-resource "aws_network_interface_attachment" "default" {
-  count                = "${var.additional_ips_count}"
+resource "aws_network_interface_attachment" "additional" {
+  count                = "${local.additional_ips_count}"
   instance_id          = "${aws_instance.default.id}"
-  network_interface_id = "${aws_network_interface.default.*.id[count.index]}"
+  network_interface_id = "${aws_network_interface.additional.*.id[count.index]}"
   device_index         = "${1 + count.index}"
 }
 
 resource "aws_eip" "additional" {
-  count             = "${var.additional_ips_count}"
-  vpc               = true
-  network_interface = "${aws_network_interface.default.*.id[count.index]}"
+  count             = "${local.additional_ips_count}"
+  vpc               = "true"
+  network_interface = "${aws_network_interface.additional.*.id[count.index]}"
 }

--- a/eni.tf
+++ b/eni.tf
@@ -1,0 +1,27 @@
+resource "aws_network_interface" "default" {
+  count     = "${var.additional_ips_count}"
+  subnet_id = "${var.subnets[0]}"
+
+  security_groups = [
+    "${compact(concat(list(var.create_default_security_group ? join("", aws_security_group.default.*.id) : ""), var.security_groups))}",
+  ]
+
+  tags {
+    Name      = "${module.label.id}"
+    Namespace = "${var.namespace}"
+    Stage     = "${var.stage}"
+  }
+}
+
+resource "aws_network_interface_attachment" "default" {
+  count                = "${var.additional_ips_count}"
+  instance_id          = "${aws_instance.default.id}"
+  network_interface_id = "${aws_network_interface.default.*.id[count.index]}"
+  device_index         = "${1 + count.index}"
+}
+
+resource "aws_eip" "additional" {
+  count             = "${var.additional_ips_count}"
+  vpc               = true
+  network_interface = "${aws_network_interface.default.*.id[count.index]}"
+}

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "default" {
 
 # Apply the tf_label module for this resource
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.1"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.0"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"
@@ -106,7 +106,7 @@ resource "aws_instance" "default" {
 
   key_name = "${var.ssh_key_pair}"
 
-  subnet_id = "${var.subnets[0]}"
+  subnet_id = "${var.subnet}"
 
   tags {
     Name      = "${module.label.id}"
@@ -118,7 +118,7 @@ resource "aws_instance" "default" {
 resource "aws_eip" "default" {
   count             = "${var.associate_public_ip_address && var.instance_enabled ? 1 : 0}"
   network_interface = "${aws_instance.default.primary_network_interface_id}"
-  vpc               = true
+  vpc               = "true"
 }
 
 # Restart dead or hung instance

--- a/main.tf
+++ b/main.tf
@@ -116,9 +116,9 @@ resource "aws_instance" "default" {
 }
 
 resource "aws_eip" "default" {
-  count    = "${var.associate_public_ip_address && var.instance_enabled ? 1 : 0}"
-  instance = "${aws_instance.default.id}"
-  vpc      = true
+  count             = "${var.associate_public_ip_address && var.instance_enabled ? 1 : 0}"
+  network_interface = "${aws_instance.default.primary_network_interface_id}"
+  vpc               = true
 }
 
 # Restart dead or hung instance

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "default" {
 
 # Apply the tf_label module for this resource
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.1"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,3 +33,7 @@ output "role" {
 output "alarm" {
   value = "${join("", aws_cloudwatch_metric_alarm.default.*.id)}"
 }
+
+output "additional_eni_ids" {
+  value = "${zipmap(aws_network_interface.default.*.id, aws_eip.additional.*.public_ip)}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,5 +35,5 @@ output "alarm" {
 }
 
 output "additional_eni_ids" {
-  value = "${zipmap(aws_network_interface.default.*.id, aws_eip.additional.*.public_ip)}"
+  value = "${zipmap(aws_network_interface.additional.*.id, aws_eip.additional.*.public_ip)}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -21,9 +21,7 @@ variable "security_groups" {
   default = []
 }
 
-variable "subnets" {
-  type = "list"
-}
+variable "subnet" {}
 
 variable "namespace" {}
 

--- a/variables.tf
+++ b/variables.tf
@@ -110,3 +110,8 @@ variable "instance_enabled" {
   description = "Flag for creating an instance. Set to false if it is necessary to skip instance creation"
   default     = "true"
 }
+
+variable "additional_ips_count" {
+  description = "Count of additional EIPs"
+  default     = "0"
+}


### PR DESCRIPTION
## What

* Add additional ENIs with EIPs capability
* Add `.travis.yml` manifest

## Why

* In case we're using `terraform-aws-ec2-instance` we need option to have additional ENIs with EIPs for full NAT