### PR TITLE
Prevent Security Group Rules creation if Security Group is not being created

### DIFF
--- a/security_group.tf
+++ b/security_group.tf
@@ -11,6 +11,7 @@ resource "aws_security_group" "default" {
 }
 
 resource "aws_security_group_rule" "egress" {
+  count             = "${var.create_default_security_group ? 1 : 0}"
   type              = "egress"
   from_port         = 0
   to_port           = 65535
@@ -20,7 +21,7 @@ resource "aws_security_group_rule" "egress" {
 }
 
 resource "aws_security_group_rule" "ingress" {
-  count             = "${length(compact(var.allowed_ports))}"
+  count             = "${var.create_default_security_group ? length(compact(var.allowed_ports)) : 0}"
   type              = "ingress"
   from_port         = "${element(var.allowed_ports, count.index)}"
   to_port           = "${element(var.allowed_ports, count.index)}"

--- a/security_group.tf
+++ b/security_group.tf
@@ -11,7 +11,7 @@ resource "aws_security_group" "default" {
 }
 
 resource "aws_security_group_rule" "egress" {
-  count             = "${var.create_default_security_group ? 1 : 0}"
+  count             = "${var.create_default_security_group == "true" ? 1 : 0}"
   type              = "egress"
   from_port         = 0
   to_port           = 65535
@@ -21,7 +21,7 @@ resource "aws_security_group_rule" "egress" {
 }
 
 resource "aws_security_group_rule" "ingress" {
-  count             = "${var.create_default_security_group ? length(compact(var.allowed_ports)) : 0}"
+  count             = "${var.create_default_security_group == "true" ? length(compact(var.allowed_ports)) : 0}"
   type              = "ingress"
   from_port         = "${element(var.allowed_ports, count.index)}"
   to_port           = "${element(var.allowed_ports, count.index)}"


### PR DESCRIPTION
## What
* Prevent Security Group Rules creation if Security Group is not being created

## Why
* https://github.com/cloudposse/terraform-aws-ec2-instance/issues/18

## Plan
![image](https://user-images.githubusercontent.com/1134449/33173444-cedb5a12-d05c-11e7-8732-0e4a17c33c29.png)
