### PR TITLE
Remove generated user data from module (breaking change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Included features:
 * Automatically create a Security Group
 * Option to switch EIP attachment
 * CloudWatch monitoring and automatic reboot if instance hangs
-* [Github Authorized Keys](https://github.com/cloudposse/terraform-template-user-data-github-authorized-keys)
 * Assume Role capability
 
 ## Usage
@@ -37,9 +36,6 @@ module "instance" {
 module "kafka_instance" {
   source                      = "git::https://github.com/cloudposse/terraform-aws-ec2-instance.git?ref=master"
   ssh_key_pair                = "${var.ssh_key_pair}"
-  github_api_token            = "${var.github_api_token}"
-  github_organization         = "${var.github_organization}"
-  github_team                 = "${var.github_team}"
   vpc_id                      = "${var.vpc_id}"
   security_groups             = ["${var.security_groups}"]
   subnet                      = "${var.subnet}"
@@ -56,7 +52,6 @@ module "kafka_instance" {
 This module depends on these modules:
 
 * [terraform-null-label](https://github.com/cloudposse/terraform-null-label)
-* [terraform-template-user-data-github-authorized-keys](https://github.com/cloudposse/terraform-template-user-data-github-authorized-keys)
 
 It is necessary to run `terraform get` to download those modules.
 
@@ -81,9 +76,6 @@ resource "aws_ami_from_instance" "example" {
 | `instance_enabled`              |                     `true`                     | Flag for creating an instance. Set to false if it is necessary to skip instance creation               |    No    |
 | `create_default_security_group` |                     `true`                     | Flag for creation default Security Group with Egress traffic allowed only                              |    No    |
 | `ssh_key_pair`                  |                       ``                       | SSH key pair to be provisioned on instance                                                             |   Yes    |
-| `github_api_token`              |                       ``                       | GitHub API token                                                                                       |    No    |
-| `github_organization`           |                       ``                       | GitHub organization name                                                                               |    No    |
-| `github_team`                   |                       ``                       | GitHub team                                                                                            |    No    |
 | `instance_type`                 |                   `t2.micro`                   | The type of the creating instance (e.g. `t2.micro`)                                                    |    No    |
 | `vpc_id`                        |                       ``                       | The ID of the VPC that the creating instance security group belongs to                                 |   Yes    |
 | `security_groups`               |                      `[]`                      | List of Security Group IDs allowed to connect to creating instance                                     |   Yes    |

--- a/main.tf
+++ b/main.tf
@@ -92,7 +92,6 @@ resource "aws_instance" "default" {
   ebs_optimized               = "${var.ebs_optimized}"
   disable_api_termination     = "${var.disable_api_termination}"
   user_data                   = "${var.user_data}"
-  user_data_base64            = "${var.user_data_base64}"
   iam_instance_profile        = "${aws_iam_instance_profile.default.name}"
   associate_public_ip_address = "${var.associate_public_ip_address}"
   key_name                    = "${var.ssh_key_pair}"

--- a/main.tf
+++ b/main.tf
@@ -84,14 +84,6 @@ resource "aws_iam_role" "default" {
   assume_role_policy = "${data.aws_iam_policy_document.default.json}"
 }
 
-# Apply the tf_github_authorized_keys module for this resource
-module "github_authorized_keys" {
-  source              = "git::https://github.com/cloudposse/terraform-template-user-data-github-authorized-keys.git?ref=tags/0.1.2"
-  github_api_token    = "${var.github_api_token}"
-  github_organization = "${var.github_organization}"
-  github_team         = "${var.github_team}"
-}
-
 resource "aws_instance" "default" {
   count                       = "${local.instance_count}"
   ami                         = "${local.ami}"
@@ -99,7 +91,8 @@ resource "aws_instance" "default" {
   instance_type               = "${var.instance_type}"
   ebs_optimized               = "${var.ebs_optimized}"
   disable_api_termination     = "${var.disable_api_termination}"
-  user_data                   = "${data.template_file.user_data.rendered}"
+  user_data                   = "${var.user_data}"
+  user_data_base64            = "${var.user_data_base64}"
   iam_instance_profile        = "${aws_iam_instance_profile.default.name}"
   associate_public_ip_address = "${var.associate_public_ip_address}"
   key_name                    = "${var.ssh_key_pair}"

--- a/user_data.tf
+++ b/user_data.tf
@@ -1,8 +1,0 @@
-data "template_file" "user_data" {
-  template = "${file("${path.module}/user-data/user_data.sh")}"
-
-  vars {
-    user_data       = "${join("\n", compact(concat(var.user_data, list(module.github_authorized_keys.user_data))))}"
-    welcome_message = "${var.welcome_message}"
-  }
-}

--- a/variables.tf
+++ b/variables.tf
@@ -99,12 +99,6 @@ variable "monitoring" {
   default     = "true"
 }
 
-variable "user_data" {
-  description = "User data to provide when launching the instance"
-  type        = "list"
-  default     = []
-}
-
 variable "private_ip" {
   description = "Private IP address to associate with the instance in a VPC"
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -12,11 +12,6 @@ variable "user_data" {
   default     = ""
 }
 
-variable "user_data_base64" {
-  description = " Can be used instead of user_data to pass base64-encoded binary data directly. Use this instead of user_data whenever the value is not a valid UTF-8 string."
-  default     = ""
-}
-
 variable "instance_type" {
   description = "The type of the creating instance"
   default     = "t2.micro"

--- a/variables.tf
+++ b/variables.tf
@@ -2,24 +2,19 @@ variable "ssh_key_pair" {
   description = "SSH key pair to be provisioned on instance"
 }
 
-variable "github_api_token" {
-  description = "GitHub API token"
-  default     = ""
-}
-
-variable "github_organization" {
-  description = "GitHub organization name"
-  default     = ""
-}
-
-variable "github_team" {
-  description = "GitHub team"
-  default     = ""
-}
-
 variable "associate_public_ip_address" {
   description = "Associate a public ip address with the creating instance"
   default     = "true"
+}
+
+variable "user_data" {
+  description = "The user data to provide when launching the instance. Do not pass gzip-compressed data via this argument"
+  default     = ""
+}
+
+variable "user_data_base64" {
+  description = " Can be used instead of user_data to pass base64-encoded binary data directly. Use this instead of user_data whenever the value is not a valid UTF-8 string."
+  default     = ""
 }
 
 variable "instance_type" {


### PR DESCRIPTION
## what
* Remove generated user data from module

## why
* Too opinionated
* User data not compatible with a wide array of images
* Assumed bash
* Required github authorized keys, even if it wasn't supported by image
* User data should be passed in by caller

## upgrading
* To upgrade to this module, pass in required script to `user_data` variable
