### PR TITLE
Use string comparison for booleans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Module directory
 .terraform/
 .idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ resource "aws_ami_from_instance" "example" {
 
 | Name                            |                    Default                     | Description                                                                                            | Required |
 |:--------------------------------|:----------------------------------------------:|:-------------------------------------------------------------------------------------------------------|:--------:|
+| `region`                        |                       ``                       | AWS Region the instance is launched in. Optional. If not provided, the current region will be used     |   No     |
 | `namespace`                     |                       ``                       | Namespace (e.g. `cp` or `cloudposse`)                                                                  |   Yes    |
 | `stage`                         |                       ``                       | Stage (e.g. `prod`, `dev`, `staging`                                                                   |   Yes    |
 | `name`                          |                       ``                       | Name  (e.g. `bastion` or `db`)                                                                         |   Yes    |

--- a/eni.tf
+++ b/eni.tf
@@ -1,5 +1,5 @@
 locals {
-  additional_ips_count = "${var.associate_public_ip_address && var.instance_enabled && var.additional_ips_count > 0 ? var.additional_ips_count : 0}"
+  additional_ips_count = "${var.associate_public_ip_address == "true" && var.instance_enabled == "true" && var.additional_ips_count > 0 ? var.additional_ips_count : 0}"
 }
 
 resource "aws_network_interface" "additional" {
@@ -7,7 +7,7 @@ resource "aws_network_interface" "additional" {
   subnet_id = "${var.subnet}"
 
   security_groups = [
-    "${compact(concat(list(var.create_default_security_group ? join("", aws_security_group.default.*.id) : ""), var.security_groups))}",
+    "${compact(concat(list(var.create_default_security_group == "true" ? join("", aws_security_group.default.*.id) : ""), var.security_groups))}",
   ]
 
   tags = "${module.label.tags}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,7 +30,7 @@ output "ssh_key_pair" {
 
 output "security_group_ids" {
   description = "ID on the new AWS Security Group associated with creating instance"
-  value       = "${compact(concat(list(var.create_default_security_group ? join("", aws_security_group.default.*.id) : ""), var.security_groups))}"
+  value       = "${compact(concat(list(var.create_default_security_group == "true" ? join("", aws_security_group.default.*.id) : ""), var.security_groups))}"
 }
 
 output "role" {

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,7 @@ variable "security_groups" {
 }
 
 variable "allowed_ports" {
+  type        = "list"
   description = "List of allowed ingress ports"
   default     = []
 }
@@ -65,7 +66,7 @@ variable "tags" {
 }
 
 variable "region" {
-  description = "Region of instance launched in"
+  description = "AWS Region the instance is launched in"
   default     = ""
 }
 
@@ -110,6 +111,7 @@ variable "ipv6_address_count" {
 }
 
 variable "ipv6_addresses" {
+  type        = "list"
   description = "List of IPv6 addresses from the range of the subnet to associate with the primary network interface"
   default     = []
 }
@@ -130,6 +132,7 @@ variable "root_iops" {
 }
 
 variable "ebs_device_name" {
+  type        = "list"
   description = "Name of the ebs device to mount"
   default     = ["/dev/xvdb", "/dev/xvdc", "/dev/xvdd", "/dev/xvde", "/dev/xvdf", "/dev/xvdg", "/dev/xvdh", "/dev/xvdi", "/dev/xvdj", "/dev/xvdk", "/dev/xvdl", "/dev/xvdm", "/dev/xvdn", "/dev/xvdo", "/dev/xvdp", "/dev/xvdq", "/dev/xvdr", "/dev/xvds", "/dev/xvdt", "/dev/xvdu", "/dev/xvdv", "/dev/xvdw", "/dev/xvdx", "/dev/xvdy", "/dev/xvdz"]
 }


### PR DESCRIPTION
## what
* Use string comparison for booleans

## why
* Terraform does not work correctly with boolean values
* Using strings instead of booleans is recommended
```
It is recommended for now to specify boolean values for variables as the strings "true" 
and "false", to avoid some caveats in the conversion process
```


## references
* https://www.terraform.io/docs/configuration/variables.html#booleans
