### PR TITLE
Allow associating a public IP to the instance without assigning an Elastic IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,29 +73,30 @@ resource "aws_ami_from_instance" "example" {
 | `name`                          |                       ``                       | Name  (e.g. `bastion` or `db`)                                                                         |   Yes    |
 | `attributes`                    |                      `[]`                      | Additional attributes (e.g. `policy` or `role`)                                                        |    No    |
 | `tags`                          |                      `{}`                      | Additional tags  (e.g. `map("BusinessUnit","XYZ")`                                                     |    No    |
-| `ami`                           |                       ``                       | By default it is an AMI provided by Amazon with Ubuntu 16.04                                           |    No    |
-| `instance_enabled`              |                     `true`                     | Flag for creating an instance. Set to false if it is necessary to skip instance creation               |    No    |
-| `create_default_security_group` |                     `true`                     | Flag for creation default Security Group with Egress traffic allowed only                              |    No    |
-| `ssh_key_pair`                  |                       ``                       | SSH key pair to be provisioned on instance                                                             |   Yes    |
-| `instance_type`                 |                   `t2.micro`                   | The type of the creating instance (e.g. `t2.micro`)                                                    |    No    |
-| `vpc_id`                        |                       ``                       | The ID of the VPC that the creating instance security group belongs to                                 |   Yes    |
-| `security_groups`               |                      `[]`                      | List of Security Group IDs allowed to connect to creating instance                                     |   Yes    |
-| `allowed_ports`                 |                      `[]`                      | List of allowed ingress ports e.g. ["22", "80", "443"]                                                 |    No    |
-| `subnet`                        |                       ``                       | VPC Subnet ID creating instance launched in                                                            |   Yes    |
-| `associate_public_ip_address`   |                     `true`                     | Associate a public ip address with the creating instance. Boolean value                                |    No    |
+| `ami`                           |                       ``                       | By default it is the AMI provided by Amazon with Ubuntu 16.04                                          |    No    |
+| `instance_enabled`              |                     `true`                     | Flag to control the instance creation. Set to false if it is necessary to skip instance creation       |    No    |
+| `create_default_security_group` |                     `true`                     | Create default Security Group with only Egress traffic allowed                                         |    No    |
+| `ssh_key_pair`                  |                       ``                       | SSH key pair to be provisioned on the instance                                                         |   Yes    |
+| `instance_type`                 |                   `t2.micro`                   | The type of the instance (e.g. `t2.micro`)                                                             |    No    |
+| `vpc_id`                        |                       ``                       | The ID of the VPC that the instance security group belongs to                                          |   Yes    |
+| `security_groups`               |                      `[]`                      | List of Security Group IDs allowed to connect to the instance                                          |   Yes    |
+| `allowed_ports`                 |                      `[]`                      | List of allowed ingress ports, _e.g._ ["22", "80", "443"]                                              |    No    |
+| `subnet`                        |                       ``                       | VPC Subnet ID the instance is launched in                                                              |   Yes    |
+| `associate_public_ip_address`   |                     `true`                     | Associate a public IP address with the instance                                                        |    No    |
+| `assign_eip_address`            |                     `true`                     | Assign an Elastic IP address to the instance                                                           |    No    |
 | `additional_ips_count`          |                      `0`                       | Count of additional EIPs                                                                               |    No    |
-| `private_ip`                    |                       ``                       | Private IP address to associate with the instance in a VPC                                             |    No    |
+| `private_ip`                    |                       ``                       | Private IP address to associate with the instance in the VPC                                           |    No    |
 | `source_dest_check`             |                     `true`                     | Controls if traffic is routed to the instance when the destination address does not match the instance |    No    |
 | `ipv6_address_count`            |                      `0`                       | Number of IPv6 addresses to associate with the primary network interface                               |    No    |
 | `ipv6_addresses`                |                      `[]`                      | List of IPv6 addresses from the range of the subnet to associate with the primary network interface    |    No    |
-| `root_volume_type`              |                     `gp2`                      | Type of root volume. Can be `standard`, `gp2` or `io1`                                                 |    No    |
+| `root_volume_type`              |                     `gp2`                      | Type of the root volume. Can be `standard`, `gp2` or `io1`                                             |    No    |
 | `root_volume_size`              |                      `10`                      | Size of the root volume in gigabytes                                                                   |    No    |
 | `root_iops`                     |                      `0`                       | Amount of provisioned IOPS. This must be set with a `root_volume_type` of `io1`                        |    No    |
-| `ebs_device_name`               |                 `[/dev/xvdb]`                  | Name of the ebs device to mount                                                                        |    No    |
-| `ebs_volume_type`               |                     `gp2`                      | Type of EBS volume. Can be standard, `gp2` or `io1`                                                    |    No    |
+| `ebs_device_name`               |                 `[/dev/xvdb]`                  | Name of the EBS device to mount                                                                        |    No    |
+| `ebs_volume_type`               |                     `gp2`                      | Type of EBS volume. Can be `standard`, `gp2` or `io1`                                                  |    No    |
 | `ebs_volume_size`               |                      `10`                      | Size of the EBS volume in gigabytes                                                                    |    No    |
-| `ebs_iops`                      |                      `0`                       | Amount of provisioned IOPS. This must be set with a `ebs_volume_type` of `io1`                         |    No    |
-| `ebs_volume_count`              |                      `0`                       | Count of EBS which will be attched to instance                                                         |    No    |
+| `ebs_iops`                      |                      `0`                       | Amount of provisioned IOPS. This must be set if `ebs_volume_type` is set to `io1`                      |    No    |
+| `ebs_volume_count`              |                      `0`                       | Count of EBS volumes that will be attached to the instance                                             |    No    |
 | `delete_on_termination`         |                     `true`                     | Whether the volume should be destroyed on instance termination                                         |    No    |
 | `comparison_operator`           |        `GreaterThanOrEqualToThreshold`         | Arithmetic operation to use when comparing the specified Statistic and Threshold                       |    No    |
 | `metric_name`                   |          `StatusCheckFailed_Instance`          | Name for the alarm's associated metric                                                                 |    No    |
@@ -111,16 +112,16 @@ resource "aws_ami_from_instance" "example" {
 | Name                           | Description                                                        |
 |:-------------------------------|:-------------------------------------------------------------------|
 | `id`                           | Disambiguated ID                                                   |
-| `private_dns`                  | Private DNS of instance                                            |
-| `private_ip`                   | Private IP of instance                                             |
-| `public_ip`                    | Public IP of instance (or EIP )                                    |
-| `public_dns`                   | Public DNS of instance (or DNS of EIP)                             |
+| `private_dns`                  | Private DNS of the instance                                        |
+| `private_ip`                   | Private IP of the instance                                         |
+| `public_ip`                    | Public IP of the instance (or EIP )                                |
+| `public_dns`                   | Public DNS of the instance (or DNS of EIP)                         |
 | `ssh_key_pair`                 | Name of used AWS SSH key                                           |
-| `security_group_id`            | ID on the new AWS Security Group associated with creating instance |
-| `role`                         | Name of AWS IAM Role associated with creating instance             |
+| `security_group_id`            | ID of the AWS Security Group associated with the instance          |
+| `role`                         | Name of the AWS IAM Role associated with the instance              |
 | `alarm`                        | CloudWatch Alarm ID                                                |
-| `additional_eni_ids`           | Map of ENI with EIP                                                |
-| `ebs_ids`                      | ID of EBSs                                                         |
+| `additional_eni_ids`           | Map of ENI to EIP                                                  |
+| `ebs_ids`                      | IDs of EBSs                                                        |
 | `primary_network_interface_id` | ID of the instance's primary network interface                     |
 | `network_interface_id`         | ID of the network interface that was created with the instance     |
 

--- a/main.tf
+++ b/main.tf
@@ -117,13 +117,13 @@ resource "aws_instance" "default" {
 }
 
 resource "aws_eip" "default" {
-  count             = "${var.associate_public_ip_address == "true" && var.instance_enabled == "true" ? 1 : 0}"
+  count             = "${var.associate_public_ip_address == "true" && var.assign_eip_address == "true" && var.instance_enabled == "true" ? 1 : 0}"
   network_interface = "${aws_instance.default.primary_network_interface_id}"
   vpc               = "true"
 }
 
 resource "null_resource" "eip" {
-  count = "${var.associate_public_ip_address == "true" && var.instance_enabled == "true" ? 1 : 0}"
+  count = "${var.associate_public_ip_address == "true" && var.assign_eip_address == "true" && var.instance_enabled == "true" ? 1 : 0}"
 
   triggers {
     public_dns = "ec2-${replace(aws_eip.default.public_ip, ".", "-")}.${local.region == "us-east-1" ? "compute-1" : "${local.region}.compute"}.amazonaws.com"

--- a/variables.tf
+++ b/variables.tf
@@ -1,28 +1,33 @@
 variable "ssh_key_pair" {
-  description = "SSH key pair to be provisioned on instance"
+  description = "SSH key pair to be provisioned on the instance"
 }
 
 variable "associate_public_ip_address" {
-  description = "Associate a public ip address with the creating instance"
+  description = "Associate a public IP address with the instance"
+  default     = "true"
+}
+
+variable "assign_eip_address" {
+  description = "Assign an Elastic IP address to the instance"
   default     = "true"
 }
 
 variable "user_data" {
-  description = "The user data to provide when launching the instance. Do not pass gzip-compressed data via this argument"
+  description = "Instance user data. Do not pass gzip-compressed data via this argument"
   default     = ""
 }
 
 variable "instance_type" {
-  description = "The type of the creating instance"
+  description = "The type of the instance"
   default     = "t2.micro"
 }
 
 variable "vpc_id" {
-  description = "The ID of the VPC that the creating instance security group belongs to"
+  description = "The ID of the VPC that the instance security group belongs to"
 }
 
 variable "security_groups" {
-  description = "List of Security Group IDs allowed to connect to creating instance"
+  description = "List of Security Group IDs allowed to connect to the instance"
   type        = "list"
   default     = []
 }
@@ -34,7 +39,7 @@ variable "allowed_ports" {
 }
 
 variable "subnet" {
-  description = "VPC Subnet ID creating instance launched in"
+  description = "VPC Subnet ID the instance is launched in"
 }
 
 variable "namespace" {
@@ -71,12 +76,12 @@ variable "region" {
 }
 
 variable "availability_zone" {
-  description = "Availability Zone of instance launched in. If not set will be launched in frist AZ of region"
+  description = "Availability Zone the instance is launched in. If not set, will be launched in the first AZ of the region"
   default     = ""
 }
 
 variable "ami" {
-  description = "The AMI to use for the instance. By default it is an AMI provided by Amazon with Ubuntu 16.04"
+  description = "The AMI to use for the instance. By default it is the AMI provided by Amazon with Ubuntu 16.04"
   default     = ""
 }
 
@@ -96,7 +101,7 @@ variable "monitoring" {
 }
 
 variable "private_ip" {
-  description = "Private IP address to associate with the instance in a VPC"
+  description = "Private IP address to associate with the instance in the VPC"
   default     = ""
 }
 
@@ -133,17 +138,17 @@ variable "root_iops" {
 
 variable "ebs_device_name" {
   type        = "list"
-  description = "Name of the ebs device to mount"
+  description = "Name of the EBS device to mount"
   default     = ["/dev/xvdb", "/dev/xvdc", "/dev/xvdd", "/dev/xvde", "/dev/xvdf", "/dev/xvdg", "/dev/xvdh", "/dev/xvdi", "/dev/xvdj", "/dev/xvdk", "/dev/xvdl", "/dev/xvdm", "/dev/xvdn", "/dev/xvdo", "/dev/xvdp", "/dev/xvdq", "/dev/xvdr", "/dev/xvds", "/dev/xvdt", "/dev/xvdu", "/dev/xvdv", "/dev/xvdw", "/dev/xvdx", "/dev/xvdy", "/dev/xvdz"]
 }
 
 variable "ebs_volume_type" {
-  description = "The type of ebs volume. Can be standard, gp2 or io1"
+  description = "The type of EBS volume. Can be standard, gp2 or io1"
   default     = "gp2"
 }
 
 variable "ebs_volume_size" {
-  description = "Size of the ebs volume in gigabytes"
+  description = "Size of the EBS volume in gigabytes"
   default     = "10"
 }
 
@@ -153,7 +158,7 @@ variable "ebs_iops" {
 }
 
 variable "ebs_volume_count" {
-  description = "Count of EBS which will be attched to instance"
+  description = "Count of EBS volumes that will be attached to the instance"
   default     = "0"
 }
 
@@ -172,7 +177,7 @@ variable "comparison_operator" {
 }
 
 variable "metric_name" {
-  description = "The name for the alarm's associated metric. Possible values you can find in https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ec2-metricscollected.html ."
+  description = "The name for the alarm's associated metric. Allowed values can be found in https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ec2-metricscollected.html"
   default     = "StatusCheckFailed_Instance"
 }
 
@@ -182,22 +187,22 @@ variable "evaluation_periods" {
 }
 
 variable "metric_namespace" {
-  description = "The namespace for the alarm's associated metric. Possible values you can find in https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-namespaces.html ."
+  description = "The namespace for the alarm's associated metric. Allowed values can be found in https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-namespaces.html"
   default     = "AWS/EC2"
 }
 
 variable "applying_period" {
-  description = "The period in seconds over which the specified statistic is applied."
+  description = "The period in seconds over which the specified statistic is applied"
   default     = "60"
 }
 
 variable "statistic_level" {
-  description = "The statistic to apply to the alarm's associated metric. Possible values are: SampleCount, Average, Sum, Minimum, Maximum"
+  description = "The statistic to apply to the alarm's associated metric. Allowed values are: SampleCount, Average, Sum, Minimum, Maximum"
   default     = "Maximum"
 }
 
 variable "metric_threshold" {
-  description = "The value against which the specified statistic is compared."
+  description = "The value against which the specified statistic is compared"
   default     = "1"
 }
 
@@ -206,12 +211,12 @@ variable "default_alarm_action" {
 }
 
 variable "create_default_security_group" {
-  description = "Create default Security Group with Egress traffic allowed only"
+  description = "Create default Security Group with only Egress traffic allowed"
   default     = "true"
 }
 
 variable "instance_enabled" {
-  description = "Flag for creating an instance. Set to false if it is necessary to skip instance creation"
+  description = "Flag to control the instance creation. Set to false if it is necessary to skip instance creation"
   default     = "true"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -132,7 +132,7 @@ variable "root_volume_size" {
 }
 
 variable "root_iops" {
-  description = "Amount of provisioned IOPS. This must be set with a root_volume_type of io1"
+  description = "Amount of provisioned IOPS. This must be set if root_volume_type is set to `io1`"
   default     = "0"
 }
 


### PR DESCRIPTION
## what
* Allow associating a public IP to the instance without assigning an Elastic IP

## why
* To separately control public and Elastic IPs
* A public IP could be associated to the instance without assigning an Elastic IP
