### PR TITLE
Use `owners` with `data.aws_ami.info`

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ Available targets:
   lint                                Lint terraform code
 
 ```
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -110,6 +109,7 @@ Available targets:
 | additional_ips_count | Count of additional EIPs | string | `0` | no |
 | allowed_ports | List of allowed ingress ports | list | `<list>` | no |
 | ami | The AMI to use for the instance. By default it is the AMI provided by Amazon with Ubuntu 16.04 | string | `` | no |
+| ami_owner | Owner of the given AMI (ignored if `ami` unset) | string | `` | no |
 | applying_period | The period in seconds over which the specified statistic is applied | string | `60` | no |
 | assign_eip_address | Assign an Elastic IP address to the instance | string | `true` | no |
 | associate_public_ip_address | Associate a public IP address with the instance | string | `true` | no |
@@ -117,7 +117,7 @@ Available targets:
 | availability_zone | Availability Zone the instance is launched in. If not set, will be launched in the first AZ of the region | string | `` | no |
 | comparison_operator | The arithmetic operation to use when comparing the specified Statistic and Threshold. Possible values are: GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold. | string | `GreaterThanOrEqualToThreshold` | no |
 | create_default_security_group | Create default Security Group with only Egress traffic allowed | string | `true` | no |
-| default_alarm_action |  | string | `action/actions/AWS_EC2.InstanceId.Reboot/1.0` | no |
+| default_alarm_action | - | string | `action/actions/AWS_EC2.InstanceId.Reboot/1.0` | no |
 | delete_on_termination | Whether the volume should be destroyed on instance termination | string | `true` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | disable_api_termination | Enable EC2 Instance Termination Protection | string | `false` | no |
@@ -152,7 +152,7 @@ Available targets:
 | tags | Additional tags | map | `<map>` | no |
 | user_data | Instance user data. Do not pass gzip-compressed data via this argument | string | `` | no |
 | vpc_id | The ID of the VPC that the instance security group belongs to | string | - | yes |
-| welcome_message |  | string | `` | no |
+| welcome_message | - | string | `` | no |
 
 ## Outputs
 
@@ -263,7 +263,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2018 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,4 +1,3 @@
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -6,6 +5,7 @@
 | additional_ips_count | Count of additional EIPs | string | `0` | no |
 | allowed_ports | List of allowed ingress ports | list | `<list>` | no |
 | ami | The AMI to use for the instance. By default it is the AMI provided by Amazon with Ubuntu 16.04 | string | `` | no |
+| ami_owner | Owner of the given AMI (ignored if `ami` unset) | string | `` | no |
 | applying_period | The period in seconds over which the specified statistic is applied | string | `60` | no |
 | assign_eip_address | Assign an Elastic IP address to the instance | string | `true` | no |
 | associate_public_ip_address | Associate a public IP address with the instance | string | `true` | no |
@@ -13,7 +13,7 @@
 | availability_zone | Availability Zone the instance is launched in. If not set, will be launched in the first AZ of the region | string | `` | no |
 | comparison_operator | The arithmetic operation to use when comparing the specified Statistic and Threshold. Possible values are: GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold. | string | `GreaterThanOrEqualToThreshold` | no |
 | create_default_security_group | Create default Security Group with only Egress traffic allowed | string | `true` | no |
-| default_alarm_action |  | string | `action/actions/AWS_EC2.InstanceId.Reboot/1.0` | no |
+| default_alarm_action | - | string | `action/actions/AWS_EC2.InstanceId.Reboot/1.0` | no |
 | delete_on_termination | Whether the volume should be destroyed on instance termination | string | `true` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | disable_api_termination | Enable EC2 Instance Termination Protection | string | `false` | no |
@@ -48,7 +48,7 @@
 | tags | Additional tags | map | `<map>` | no |
 | user_data | Instance user data. Do not pass gzip-compressed data via this argument | string | `` | no |
 | vpc_id | The ID of the VPC that the instance security group belongs to | string | - | yes |
-| welcome_message |  | string | `` | no |
+| welcome_message | - | string | `` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ data "aws_ami" "info" {
     values = ["${local.ami}"]
   }
 
-  owners = [ "${local.ami_owner}"]
+  owners = ["${local.ami_owner}"]
 }
 
 module "label" {

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ locals {
   ebs_iops             = "${var.ebs_volume_type == "io1" ? var.ebs_iops : "0"}"
   availability_zone    = "${var.availability_zone != "" ? var.availability_zone : data.aws_subnet.default.availability_zone}"
   ami                  = "${var.ami != "" ? var.ami : data.aws_ami.default.image_id}"
+  ami_owner            = "${var.ami != "" ? var.ami_owner : data.aws_ami.default.owner_id}"
   root_volume_type     = "${var.root_volume_type != "" ? var.root_volume_type : data.aws_ami.info.root_device_type}"
   public_dns           = "${var.associate_public_ip_address == "true" && var.assign_eip_address == "true" && var.instance_enabled == "true" ?  data.null_data_source.eip.outputs["public_dns"] : join("", aws_instance.default.*.public_dns)}"
 }
@@ -56,6 +57,8 @@ data "aws_ami" "info" {
     name   = "image-id"
     values = ["${local.ami}"]
   }
+
+  owners = [ "${local.ami_owner}"]
 }
 
 module "label" {

--- a/variables.tf
+++ b/variables.tf
@@ -86,6 +86,11 @@ variable "ami" {
   default     = ""
 }
 
+variable "ami_owner" {
+  description = "Owner of the given AMI (ignored if `ami` unset)"
+  default     = ""
+}
+
 variable "ebs_optimized" {
   description = "Launched EC2 instance will be EBS-optimized"
   default     = "false"


### PR DESCRIPTION
The latest `terraform-aws-provider` appears to require this, so let's
humor it, and either supply it in case we're using the default AMI, or
allow the user to provide it.