### PR TITLE
Remove `network_interface_id` output

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017-2018 Cloud Posse, LLC
+   Copyright 2017-2019 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,6 @@ Available targets:
 | alarm | CloudWatch Alarm ID |
 | ebs_ids | IDs of EBSs |
 | id | Disambiguated ID of the instance |
-| network_interface_id | ID of the network interface that was created with the instance |
 | primary_network_interface_id | ID of the instance's primary network interface |
 | private_dns | Private DNS of instance |
 | private_ip | Private IP of instance |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -58,7 +58,6 @@
 | alarm | CloudWatch Alarm ID |
 | ebs_ids | IDs of EBSs |
 | id | Disambiguated ID of the instance |
-| network_interface_id | ID of the network interface that was created with the instance |
 | primary_network_interface_id | ID of the instance's primary network interface |
 | private_dns | Private DNS of instance |
 | private_ip | Private IP of instance |

--- a/outputs.tf
+++ b/outputs.tf
@@ -57,8 +57,3 @@ output "primary_network_interface_id" {
   description = "ID of the instance's primary network interface"
   value       = "${join("", aws_instance.default.*.primary_network_interface_id)}"
 }
-
-output "network_interface_id" {
-  description = "ID of the network interface that was created with the instance"
-  value       = "${join("", aws_instance.default.*.network_interface_id)}"
-}


### PR DESCRIPTION
## what
* Remove `network_interface_id` output

## why
* No longer supported https://www.terraform.io/docs/providers/aws/r/instance.html
* Closes #37 
