### PR TITLE
Fix `public_ip` output variable error when instance is not enabled.

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "public_ip" {
   description = "Public IP of instance (or EIP)"
-  value = coalesce(
+  value = var.instance_enabled ? coalesce(
     join("", aws_eip.default.*.public_ip),
     join("", aws_instance.default.*.public_ip)
-  )
+  ) : ""
 }
 
 output "private_ip" {


### PR DESCRIPTION
Terraform changed handling of `coalesce` function to error out when there are no non-null non-empty elements on the list. This results in an error while configuring an instance with no EIP assigned that is not enabled.