### PR TITLE
Allow a permissions boundary to be attached

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Available targets:
 | monitoring | Launched EC2 instance will have detailed monitoring enabled | bool | `true` | no |
 | name | Name  (e.g. `bastion` or `db`) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | `` | no |
+| permissions_boundary_arn | Policy ARN to attach to instance role as a permissions boundary | string | `` | no |
 | private_ip | Private IP address to associate with the instance in the VPC | string | `` | no |
 | region | AWS Region the instance is launched in | string | `` | no |
 | root_iops | Amount of provisioned IOPS. This must be set if root_volume_type is set to `io1` | number | `0` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -35,6 +35,7 @@
 | monitoring | Launched EC2 instance will have detailed monitoring enabled | bool | `true` | no |
 | name | Name  (e.g. `bastion` or `db`) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | `` | no |
+| permissions_boundary_arn | Policy ARN to attach to instance role as a permissions boundary | string | `` | no |
 | private_ip | Private IP address to associate with the instance in the VPC | string | `` | no |
 | region | AWS Region the instance is launched in | string | `` | no |
 | root_iops | Amount of provisioned IOPS. This must be set if root_volume_type is set to `io1` | number | `0` | no |

--- a/main.tf
+++ b/main.tf
@@ -82,10 +82,11 @@ resource "aws_iam_instance_profile" "default" {
 }
 
 resource "aws_iam_role" "default" {
-  count              = local.instance_count
-  name               = module.label.id
-  path               = "/"
-  assume_role_policy = data.aws_iam_policy_document.default.json
+  count                = local.instance_count
+  name                 = module.label.id
+  path                 = "/"
+  assume_role_policy   = data.aws_iam_policy_document.default.json
+  permissions_boundary = var.permissions_boundary_arn
 }
 
 resource "aws_instance" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -281,3 +281,9 @@ variable "additional_ips_count" {
   description = "Count of additional EIPs"
   default     = 0
 }
+
+variable "permissions_boundary_arn" {
+  type        = string
+  description = "Policy ARN to attach to instance role as a permissions boundary"
+  default     = ""
+}


### PR DESCRIPTION
...as these things are useful, but must be attached to the role at
creation.