### PR TITLE
Update outputs when no public ips are allocated

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -2,7 +2,8 @@ output "public_ip" {
   description = "Public IP of instance (or EIP)"
   value = coalesce(
     join("", aws_eip.default.*.public_ip),
-    join("", aws_instance.default.*.public_ip)
+    join("", aws_instance.default.*.public_ip),
+    "Empty"
   )
 }
 


### PR DESCRIPTION
If no Public_ip or EIP are allocated to the instance, Terraform fails.

Code
```
module "NAME" {
  source = "git::https://github.com/cloudposse/terraform-aws-ec2-instance.git?ref=tags/0.12.0"

  assign_eip_address          = false
  associate_public_ip_address = false
  ...
}
```

Output
```
Error: Error in function call

  on .terraform/modules/NAME/outputs.tf line 3, in output "public_ip":
   3:   value = coalesce(
   4: 
   5: 
   6: 
    |----------------
    | aws_eip.default is empty tuple
    | aws_instance.default is tuple with 1 element

Call to function "coalesce" failed: no non-null, non-empty-string arguments.
```