### PR TITLE
use datasource for aws partition

### DIFF
--- a/cloud_watch_alarm.tf
+++ b/cloud_watch_alarm.tf
@@ -4,7 +4,7 @@ resource "null_resource" "check_alarm_action" {
   count = local.instance_count
 
   triggers = {
-    action = "arn:aws:swf:${local.region}:${data.aws_caller_identity.default.account_id}:${var.default_alarm_action}"
+    action = "arn:${data.aws_partition.current.partition}:swf:${local.region}:${data.aws_caller_identity.default.account_id}:${var.default_alarm_action}"
   }
 }
 

--- a/cloud_watch_alarm.tf
+++ b/cloud_watch_alarm.tf
@@ -4,7 +4,7 @@ resource "null_resource" "check_alarm_action" {
   count = local.instance_count
 
   triggers = {
-    action = "arn:${data.aws_partition.current.partition}:swf:${local.region}:${data.aws_caller_identity.default.account_id}:${var.default_alarm_action}"
+    action = "arn:${data.aws_partition.default.partition}:swf:${local.region}:${data.aws_caller_identity.default.account_id}:${var.default_alarm_action}"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ data "aws_caller_identity" "default" {
 data "aws_region" "default" {
 }
 
-data "aws_partition" "current" {
+data "aws_partition" "default" {
 }
 
 data "aws_subnet" "default" {

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,9 @@ data "aws_caller_identity" "default" {
 data "aws_region" "default" {
 }
 
+data "aws_partition" "current" {
+}
+
 data "aws_subnet" "default" {
   id = var.subnet
 }


### PR DESCRIPTION
the hardcoded "aws" partition breaks when creating resources in govcloud. use datasource to retrieve it instead.