### PR TITLE
Change fixtures to use us-east-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,77 +146,92 @@ Available targets:
   lint                                Lint terraform code
 
 ```
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.0 |
+| aws | ~> 2.0 |
+| null | ~> 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2.0 |
+| null | ~> 2.0 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| additional_ips_count | Count of additional EIPs | number | `0` | no |
-| allowed_ports | List of allowed ingress ports | list(number) | `<list>` | no |
-| ami | The AMI to use for the instance. By default it is the AMI provided by Amazon with Ubuntu 16.04 | string | `` | no |
-| ami_owner | Owner of the given AMI (ignored if `ami` unset) | string | `` | no |
-| applying_period | The period in seconds over which the specified statistic is applied | number | `60` | no |
-| assign_eip_address | Assign an Elastic IP address to the instance | bool | `true` | no |
-| associate_public_ip_address | Associate a public IP address with the instance | bool | `true` | no |
-| attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
-| availability_zone | Availability Zone the instance is launched in. If not set, will be launched in the first AZ of the region | string | `` | no |
-| comparison_operator | The arithmetic operation to use when comparing the specified Statistic and Threshold. Possible values are: GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold. | string | `GreaterThanOrEqualToThreshold` | no |
-| create_default_security_group | Create default Security Group with only Egress traffic allowed | bool | `true` | no |
-| default_alarm_action | Default alerm action | string | `action/actions/AWS_EC2.InstanceId.Reboot/1.0` | no |
-| delete_on_termination | Whether the volume should be destroyed on instance termination | bool | `true` | no |
-| delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
-| disable_api_termination | Enable EC2 Instance Termination Protection | bool | `false` | no |
-| ebs_device_name | Name of the EBS device to mount | list(string) | `<list>` | no |
-| ebs_iops | Amount of provisioned IOPS. This must be set with a volume_type of io1 | number | `0` | no |
-| ebs_optimized | Launched EC2 instance will be EBS-optimized | bool | `false` | no |
-| ebs_volume_count | Count of EBS volumes that will be attached to the instance | number | `0` | no |
-| ebs_volume_size | Size of the EBS volume in gigabytes | number | `10` | no |
-| ebs_volume_type | The type of EBS volume. Can be standard, gp2 or io1 | string | `gp2` | no |
-| environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | string | `` | no |
-| evaluation_periods | The number of periods over which data is compared to the specified threshold. | number | `5` | no |
-| instance_enabled | Flag to control the instance creation. Set to false if it is necessary to skip instance creation | bool | `true` | no |
-| instance_type | The type of the instance | string | `t2.micro` | no |
-| ipv6_address_count | Number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet (-1 to use subnet default) | number | `0` | no |
-| ipv6_addresses | List of IPv6 addresses from the range of the subnet to associate with the primary network interface | list(string) | `<list>` | no |
-| metric_name | The name for the alarm's associated metric. Allowed values can be found in https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ec2-metricscollected.html | string | `StatusCheckFailed_Instance` | no |
-| metric_namespace | The namespace for the alarm's associated metric. Allowed values can be found in https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-namespaces.html | string | `AWS/EC2` | no |
-| metric_threshold | The value against which the specified statistic is compared | number | `1` | no |
-| monitoring | Launched EC2 instance will have detailed monitoring enabled | bool | `true` | no |
-| name | Name  (e.g. `bastion` or `db`) | string | - | yes |
-| namespace | Namespace (e.g. `cp` or `cloudposse`) | string | `` | no |
-| permissions_boundary_arn | Policy ARN to attach to instance role as a permissions boundary | string | `` | no |
-| private_ip | Private IP address to associate with the instance in the VPC | string | `` | no |
-| region | AWS Region the instance is launched in | string | `` | no |
-| root_iops | Amount of provisioned IOPS. This must be set if root_volume_type is set to `io1` | number | `0` | no |
-| root_volume_size | Size of the root volume in gigabytes | number | `10` | no |
-| root_volume_type | Type of root volume. Can be standard, gp2 or io1 | string | `gp2` | no |
-| security_groups | List of Security Group IDs allowed to connect to the instance | list(string) | `<list>` | no |
-| source_dest_check | Controls if traffic is routed to the instance when the destination address does not match the instance. Used for NAT or VPNs | bool | `true` | no |
-| ssh_key_pair | SSH key pair to be provisioned on the instance | string | - | yes |
-| stage | Stage (e.g. `prod`, `dev`, `staging` | string | `` | no |
-| statistic_level | The statistic to apply to the alarm's associated metric. Allowed values are: SampleCount, Average, Sum, Minimum, Maximum | string | `Maximum` | no |
-| subnet | VPC Subnet ID the instance is launched in | string | - | yes |
-| tags | Additional tags | map(string) | `<map>` | no |
-| user_data | Instance user data. Do not pass gzip-compressed data via this argument | string | `` | no |
-| vpc_id | The ID of the VPC that the instance security group belongs to | string | - | yes |
-| welcome_message | Welcome message | string | `` | no |
+|------|-------------|------|---------|:--------:|
+| additional\_ips\_count | Count of additional EIPs | `number` | `0` | no |
+| allowed\_ports | List of allowed ingress ports | `list(number)` | `[]` | no |
+| ami | The AMI to use for the instance. By default it is the AMI provided by Amazon with Ubuntu 16.04 | `string` | `""` | no |
+| ami\_owner | Owner of the given AMI (ignored if `ami` unset) | `string` | `""` | no |
+| applying\_period | The period in seconds over which the specified statistic is applied | `number` | `60` | no |
+| assign\_eip\_address | Assign an Elastic IP address to the instance | `bool` | `true` | no |
+| associate\_public\_ip\_address | Associate a public IP address with the instance | `bool` | `true` | no |
+| attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| availability\_zone | Availability Zone the instance is launched in. If not set, will be launched in the first AZ of the region | `string` | `""` | no |
+| comparison\_operator | The arithmetic operation to use when comparing the specified Statistic and Threshold. Possible values are: GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold. | `string` | `"GreaterThanOrEqualToThreshold"` | no |
+| create\_default\_security\_group | Create default Security Group with only Egress traffic allowed | `bool` | `true` | no |
+| default\_alarm\_action | Default alerm action | `string` | `"action/actions/AWS_EC2.InstanceId.Reboot/1.0"` | no |
+| delete\_on\_termination | Whether the volume should be destroyed on instance termination | `bool` | `true` | no |
+| delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | `string` | `"-"` | no |
+| disable\_api\_termination | Enable EC2 Instance Termination Protection | `bool` | `false` | no |
+| ebs\_device\_name | Name of the EBS device to mount | `list(string)` | <pre>[<br>  "/dev/xvdb",<br>  "/dev/xvdc",<br>  "/dev/xvdd",<br>  "/dev/xvde",<br>  "/dev/xvdf",<br>  "/dev/xvdg",<br>  "/dev/xvdh",<br>  "/dev/xvdi",<br>  "/dev/xvdj",<br>  "/dev/xvdk",<br>  "/dev/xvdl",<br>  "/dev/xvdm",<br>  "/dev/xvdn",<br>  "/dev/xvdo",<br>  "/dev/xvdp",<br>  "/dev/xvdq",<br>  "/dev/xvdr",<br>  "/dev/xvds",<br>  "/dev/xvdt",<br>  "/dev/xvdu",<br>  "/dev/xvdv",<br>  "/dev/xvdw",<br>  "/dev/xvdx",<br>  "/dev/xvdy",<br>  "/dev/xvdz"<br>]</pre> | no |
+| ebs\_iops | Amount of provisioned IOPS. This must be set with a volume\_type of io1 | `number` | `0` | no |
+| ebs\_optimized | Launched EC2 instance will be EBS-optimized | `bool` | `false` | no |
+| ebs\_volume\_count | Count of EBS volumes that will be attached to the instance | `number` | `0` | no |
+| ebs\_volume\_size | Size of the EBS volume in gigabytes | `number` | `10` | no |
+| ebs\_volume\_type | The type of EBS volume. Can be standard, gp2 or io1 | `string` | `"gp2"` | no |
+| environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
+| evaluation\_periods | The number of periods over which data is compared to the specified threshold. | `number` | `5` | no |
+| instance\_enabled | Flag to control the instance creation. Set to false if it is necessary to skip instance creation | `bool` | `true` | no |
+| instance\_type | The type of the instance | `string` | `"t2.micro"` | no |
+| ipv6\_address\_count | Number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet (-1 to use subnet default) | `number` | `0` | no |
+| ipv6\_addresses | List of IPv6 addresses from the range of the subnet to associate with the primary network interface | `list(string)` | `[]` | no |
+| metric\_name | The name for the alarm's associated metric. Allowed values can be found in https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ec2-metricscollected.html | `string` | `"StatusCheckFailed_Instance"` | no |
+| metric\_namespace | The namespace for the alarm's associated metric. Allowed values can be found in https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-namespaces.html | `string` | `"AWS/EC2"` | no |
+| metric\_threshold | The value against which the specified statistic is compared | `number` | `1` | no |
+| monitoring | Launched EC2 instance will have detailed monitoring enabled | `bool` | `true` | no |
+| name | Name  (e.g. `bastion` or `db`) | `string` | n/a | yes |
+| namespace | Namespace (e.g. `cp` or `cloudposse`) | `string` | `""` | no |
+| permissions\_boundary\_arn | Policy ARN to attach to instance role as a permissions boundary | `string` | `""` | no |
+| private\_ip | Private IP address to associate with the instance in the VPC | `string` | `""` | no |
+| region | AWS Region the instance is launched in | `string` | `""` | no |
+| root\_iops | Amount of provisioned IOPS. This must be set if root\_volume\_type is set to `io1` | `number` | `0` | no |
+| root\_volume\_size | Size of the root volume in gigabytes | `number` | `10` | no |
+| root\_volume\_type | Type of root volume. Can be standard, gp2 or io1 | `string` | `"gp2"` | no |
+| security\_groups | List of Security Group IDs allowed to connect to the instance | `list(string)` | `[]` | no |
+| source\_dest\_check | Controls if traffic is routed to the instance when the destination address does not match the instance. Used for NAT or VPNs | `bool` | `true` | no |
+| ssh\_key\_pair | SSH key pair to be provisioned on the instance | `string` | n/a | yes |
+| stage | Stage (e.g. `prod`, `dev`, `staging` | `string` | `""` | no |
+| statistic\_level | The statistic to apply to the alarm's associated metric. Allowed values are: SampleCount, Average, Sum, Minimum, Maximum | `string` | `"Maximum"` | no |
+| subnet | VPC Subnet ID the instance is launched in | `string` | n/a | yes |
+| tags | Additional tags | `map(string)` | `{}` | no |
+| user\_data | Instance user data. Do not pass gzip-compressed data via this argument | `string` | `""` | no |
+| vpc\_id | The ID of the VPC that the instance security group belongs to | `string` | n/a | yes |
+| welcome\_message | Welcome message | `string` | `""` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| additional_eni_ids | Map of ENI to EIP |
+| additional\_eni\_ids | Map of ENI to EIP |
 | alarm | CloudWatch Alarm ID |
-| ebs_ids | IDs of EBSs |
+| ebs\_ids | IDs of EBSs |
 | id | Disambiguated ID of the instance |
 | name | Instance name |
-| primary_network_interface_id | ID of the instance's primary network interface |
-| private_dns | Private DNS of instance |
-| private_ip | Private IP of instance |
-| public_dns | Public DNS of instance (or DNS of EIP) |
-| public_ip | Public IP of instance (or EIP) |
+| primary\_network\_interface\_id | ID of the instance's primary network interface |
+| private\_dns | Private DNS of instance |
+| private\_ip | Private IP of instance |
+| public\_dns | Public DNS of instance (or DNS of EIP) |
+| public\_ip | Public IP of instance (or EIP) |
 | role | Name of AWS IAM Role associated with the instance |
-| security_group_ids | IDs on the AWS Security Groups associated with the instance |
-| ssh_key_pair | Name of the SSH key pair provisioned on the instance |
+| security\_group\_ids | IDs on the AWS Security Groups associated with the instance |
+| ssh\_key\_pair | Name of the SSH key pair provisioned on the instance |
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,72 +1,87 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.0 |
+| aws | ~> 2.0 |
+| null | ~> 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2.0 |
+| null | ~> 2.0 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| additional_ips_count | Count of additional EIPs | number | `0` | no |
-| allowed_ports | List of allowed ingress ports | list(number) | `<list>` | no |
-| ami | The AMI to use for the instance. By default it is the AMI provided by Amazon with Ubuntu 16.04 | string | `` | no |
-| ami_owner | Owner of the given AMI (ignored if `ami` unset) | string | `` | no |
-| applying_period | The period in seconds over which the specified statistic is applied | number | `60` | no |
-| assign_eip_address | Assign an Elastic IP address to the instance | bool | `true` | no |
-| associate_public_ip_address | Associate a public IP address with the instance | bool | `true` | no |
-| attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
-| availability_zone | Availability Zone the instance is launched in. If not set, will be launched in the first AZ of the region | string | `` | no |
-| comparison_operator | The arithmetic operation to use when comparing the specified Statistic and Threshold. Possible values are: GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold. | string | `GreaterThanOrEqualToThreshold` | no |
-| create_default_security_group | Create default Security Group with only Egress traffic allowed | bool | `true` | no |
-| default_alarm_action | Default alerm action | string | `action/actions/AWS_EC2.InstanceId.Reboot/1.0` | no |
-| delete_on_termination | Whether the volume should be destroyed on instance termination | bool | `true` | no |
-| delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
-| disable_api_termination | Enable EC2 Instance Termination Protection | bool | `false` | no |
-| ebs_device_name | Name of the EBS device to mount | list(string) | `<list>` | no |
-| ebs_iops | Amount of provisioned IOPS. This must be set with a volume_type of io1 | number | `0` | no |
-| ebs_optimized | Launched EC2 instance will be EBS-optimized | bool | `false` | no |
-| ebs_volume_count | Count of EBS volumes that will be attached to the instance | number | `0` | no |
-| ebs_volume_size | Size of the EBS volume in gigabytes | number | `10` | no |
-| ebs_volume_type | The type of EBS volume. Can be standard, gp2 or io1 | string | `gp2` | no |
-| environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | string | `` | no |
-| evaluation_periods | The number of periods over which data is compared to the specified threshold. | number | `5` | no |
-| instance_enabled | Flag to control the instance creation. Set to false if it is necessary to skip instance creation | bool | `true` | no |
-| instance_type | The type of the instance | string | `t2.micro` | no |
-| ipv6_address_count | Number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet (-1 to use subnet default) | number | `0` | no |
-| ipv6_addresses | List of IPv6 addresses from the range of the subnet to associate with the primary network interface | list(string) | `<list>` | no |
-| metric_name | The name for the alarm's associated metric. Allowed values can be found in https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ec2-metricscollected.html | string | `StatusCheckFailed_Instance` | no |
-| metric_namespace | The namespace for the alarm's associated metric. Allowed values can be found in https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-namespaces.html | string | `AWS/EC2` | no |
-| metric_threshold | The value against which the specified statistic is compared | number | `1` | no |
-| monitoring | Launched EC2 instance will have detailed monitoring enabled | bool | `true` | no |
-| name | Name  (e.g. `bastion` or `db`) | string | - | yes |
-| namespace | Namespace (e.g. `cp` or `cloudposse`) | string | `` | no |
-| permissions_boundary_arn | Policy ARN to attach to instance role as a permissions boundary | string | `` | no |
-| private_ip | Private IP address to associate with the instance in the VPC | string | `` | no |
-| region | AWS Region the instance is launched in | string | `` | no |
-| root_iops | Amount of provisioned IOPS. This must be set if root_volume_type is set to `io1` | number | `0` | no |
-| root_volume_size | Size of the root volume in gigabytes | number | `10` | no |
-| root_volume_type | Type of root volume. Can be standard, gp2 or io1 | string | `gp2` | no |
-| security_groups | List of Security Group IDs allowed to connect to the instance | list(string) | `<list>` | no |
-| source_dest_check | Controls if traffic is routed to the instance when the destination address does not match the instance. Used for NAT or VPNs | bool | `true` | no |
-| ssh_key_pair | SSH key pair to be provisioned on the instance | string | - | yes |
-| stage | Stage (e.g. `prod`, `dev`, `staging` | string | `` | no |
-| statistic_level | The statistic to apply to the alarm's associated metric. Allowed values are: SampleCount, Average, Sum, Minimum, Maximum | string | `Maximum` | no |
-| subnet | VPC Subnet ID the instance is launched in | string | - | yes |
-| tags | Additional tags | map(string) | `<map>` | no |
-| user_data | Instance user data. Do not pass gzip-compressed data via this argument | string | `` | no |
-| vpc_id | The ID of the VPC that the instance security group belongs to | string | - | yes |
-| welcome_message | Welcome message | string | `` | no |
+|------|-------------|------|---------|:--------:|
+| additional\_ips\_count | Count of additional EIPs | `number` | `0` | no |
+| allowed\_ports | List of allowed ingress ports | `list(number)` | `[]` | no |
+| ami | The AMI to use for the instance. By default it is the AMI provided by Amazon with Ubuntu 16.04 | `string` | `""` | no |
+| ami\_owner | Owner of the given AMI (ignored if `ami` unset) | `string` | `""` | no |
+| applying\_period | The period in seconds over which the specified statistic is applied | `number` | `60` | no |
+| assign\_eip\_address | Assign an Elastic IP address to the instance | `bool` | `true` | no |
+| associate\_public\_ip\_address | Associate a public IP address with the instance | `bool` | `true` | no |
+| attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| availability\_zone | Availability Zone the instance is launched in. If not set, will be launched in the first AZ of the region | `string` | `""` | no |
+| comparison\_operator | The arithmetic operation to use when comparing the specified Statistic and Threshold. Possible values are: GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold. | `string` | `"GreaterThanOrEqualToThreshold"` | no |
+| create\_default\_security\_group | Create default Security Group with only Egress traffic allowed | `bool` | `true` | no |
+| default\_alarm\_action | Default alerm action | `string` | `"action/actions/AWS_EC2.InstanceId.Reboot/1.0"` | no |
+| delete\_on\_termination | Whether the volume should be destroyed on instance termination | `bool` | `true` | no |
+| delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | `string` | `"-"` | no |
+| disable\_api\_termination | Enable EC2 Instance Termination Protection | `bool` | `false` | no |
+| ebs\_device\_name | Name of the EBS device to mount | `list(string)` | <pre>[<br>  "/dev/xvdb",<br>  "/dev/xvdc",<br>  "/dev/xvdd",<br>  "/dev/xvde",<br>  "/dev/xvdf",<br>  "/dev/xvdg",<br>  "/dev/xvdh",<br>  "/dev/xvdi",<br>  "/dev/xvdj",<br>  "/dev/xvdk",<br>  "/dev/xvdl",<br>  "/dev/xvdm",<br>  "/dev/xvdn",<br>  "/dev/xvdo",<br>  "/dev/xvdp",<br>  "/dev/xvdq",<br>  "/dev/xvdr",<br>  "/dev/xvds",<br>  "/dev/xvdt",<br>  "/dev/xvdu",<br>  "/dev/xvdv",<br>  "/dev/xvdw",<br>  "/dev/xvdx",<br>  "/dev/xvdy",<br>  "/dev/xvdz"<br>]</pre> | no |
+| ebs\_iops | Amount of provisioned IOPS. This must be set with a volume\_type of io1 | `number` | `0` | no |
+| ebs\_optimized | Launched EC2 instance will be EBS-optimized | `bool` | `false` | no |
+| ebs\_volume\_count | Count of EBS volumes that will be attached to the instance | `number` | `0` | no |
+| ebs\_volume\_size | Size of the EBS volume in gigabytes | `number` | `10` | no |
+| ebs\_volume\_type | The type of EBS volume. Can be standard, gp2 or io1 | `string` | `"gp2"` | no |
+| environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
+| evaluation\_periods | The number of periods over which data is compared to the specified threshold. | `number` | `5` | no |
+| instance\_enabled | Flag to control the instance creation. Set to false if it is necessary to skip instance creation | `bool` | `true` | no |
+| instance\_type | The type of the instance | `string` | `"t2.micro"` | no |
+| ipv6\_address\_count | Number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet (-1 to use subnet default) | `number` | `0` | no |
+| ipv6\_addresses | List of IPv6 addresses from the range of the subnet to associate with the primary network interface | `list(string)` | `[]` | no |
+| metric\_name | The name for the alarm's associated metric. Allowed values can be found in https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ec2-metricscollected.html | `string` | `"StatusCheckFailed_Instance"` | no |
+| metric\_namespace | The namespace for the alarm's associated metric. Allowed values can be found in https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-namespaces.html | `string` | `"AWS/EC2"` | no |
+| metric\_threshold | The value against which the specified statistic is compared | `number` | `1` | no |
+| monitoring | Launched EC2 instance will have detailed monitoring enabled | `bool` | `true` | no |
+| name | Name  (e.g. `bastion` or `db`) | `string` | n/a | yes |
+| namespace | Namespace (e.g. `cp` or `cloudposse`) | `string` | `""` | no |
+| permissions\_boundary\_arn | Policy ARN to attach to instance role as a permissions boundary | `string` | `""` | no |
+| private\_ip | Private IP address to associate with the instance in the VPC | `string` | `""` | no |
+| region | AWS Region the instance is launched in | `string` | `""` | no |
+| root\_iops | Amount of provisioned IOPS. This must be set if root\_volume\_type is set to `io1` | `number` | `0` | no |
+| root\_volume\_size | Size of the root volume in gigabytes | `number` | `10` | no |
+| root\_volume\_type | Type of root volume. Can be standard, gp2 or io1 | `string` | `"gp2"` | no |
+| security\_groups | List of Security Group IDs allowed to connect to the instance | `list(string)` | `[]` | no |
+| source\_dest\_check | Controls if traffic is routed to the instance when the destination address does not match the instance. Used for NAT or VPNs | `bool` | `true` | no |
+| ssh\_key\_pair | SSH key pair to be provisioned on the instance | `string` | n/a | yes |
+| stage | Stage (e.g. `prod`, `dev`, `staging` | `string` | `""` | no |
+| statistic\_level | The statistic to apply to the alarm's associated metric. Allowed values are: SampleCount, Average, Sum, Minimum, Maximum | `string` | `"Maximum"` | no |
+| subnet | VPC Subnet ID the instance is launched in | `string` | n/a | yes |
+| tags | Additional tags | `map(string)` | `{}` | no |
+| user\_data | Instance user data. Do not pass gzip-compressed data via this argument | `string` | `""` | no |
+| vpc\_id | The ID of the VPC that the instance security group belongs to | `string` | n/a | yes |
+| welcome\_message | Welcome message | `string` | `""` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| additional_eni_ids | Map of ENI to EIP |
+| additional\_eni\_ids | Map of ENI to EIP |
 | alarm | CloudWatch Alarm ID |
-| ebs_ids | IDs of EBSs |
+| ebs\_ids | IDs of EBSs |
 | id | Disambiguated ID of the instance |
 | name | Instance name |
-| primary_network_interface_id | ID of the instance's primary network interface |
-| private_dns | Private DNS of instance |
-| private_ip | Private IP of instance |
-| public_dns | Public DNS of instance (or DNS of EIP) |
-| public_ip | Public IP of instance (or EIP) |
+| primary\_network\_interface\_id | ID of the instance's primary network interface |
+| private\_dns | Private DNS of instance |
+| private\_ip | Private IP of instance |
+| public\_dns | Public DNS of instance (or DNS of EIP) |
+| public\_ip | Public IP of instance (or EIP) |
 | role | Name of AWS IAM Role associated with the instance |
-| security_group_ids | IDs on the AWS Security Groups associated with the instance |
-| ssh_key_pair | Name of the SSH key pair provisioned on the instance |
+| security\_group\_ids | IDs on the AWS Security Groups associated with the instance |
+| ssh\_key\_pair | Name of the SSH key pair provisioned on the instance |
 

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -1,4 +1,4 @@
-region = "us-west-1"
+region = "us-east-2"
 
 namespace = "eg"
 
@@ -6,13 +6,13 @@ stage = "test"
 
 name = "ec2-instance"
 
-availability_zones = ["us-west-1b", "us-west-1c"]
+availability_zones = ["us-east-2a", "us-east-2b"]
 
 assign_eip_address = false
 
 associate_public_ip_address = true
 
-instance_type = "t2.micro"
+instance_type = "t3.micro"
 
 allowed_ports = [22, 80, 443]
 

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -33,12 +33,12 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	privateSubnetCidrs := terraform.OutputList(t, terraformOptions, "private_subnet_cidrs")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, []string{"172.16.0.0/18", "172.16.64.0/18"}, privateSubnetCidrs)
+	assert.Equal(t, []string{"172.16.0.0/19", "172.16.32.0/19"}, privateSubnetCidrs)
 
 	// Run `terraform output` to get the value of an output variable
 	publicSubnetCidrs := terraform.OutputList(t, terraformOptions, "public_subnet_cidrs")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, []string{"172.16.128.0/18", "172.16.192.0/18"}, publicSubnetCidrs)
+	assert.Equal(t, []string{"172.16.96.0/19", "172.16.128.0/19"}, publicSubnetCidrs)
 
 	// Run `terraform output` to get the value of an output variable
 	keyName := terraform.Output(t, terraformOptions, "key_name")

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -16,7 +16,7 @@ func TestExamplesComplete(t *testing.T) {
 		TerraformDir: "../../examples/complete",
 		Upgrade:      true,
 		// Variables to pass to our Terraform code using -var-file options
-		VarFiles: []string{"fixtures.us-west-1.tfvars"},
+		VarFiles: []string{"fixtures.us-east-2.tfvars"},
 	}
 
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created
@@ -48,7 +48,7 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	publicDns := terraform.Output(t, terraformOptions, "public_dns")
 	// Verify we're getting back the outputs we expect
-	assert.Contains(t, publicDns, ".us-west-1.compute.amazonaws.com")
+	assert.Contains(t, publicDns, ".us-east-2.compute.amazonaws.com")
 
 	// Run `terraform output` to get the value of an output variable
 	role := terraform.Output(t, terraformOptions, "role")


### PR DESCRIPTION
## what
* Change example fixtures and tests to use us-east-2 region

## why
* To allow automated tests to run

## references


