### PR TITLE
Add `user_data_base64` to inputs. Add `arn` to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,8 @@ Available targets:
 | statistic\_level | The statistic to apply to the alarm's associated metric. Allowed values are: SampleCount, Average, Sum, Minimum, Maximum | `string` | `"Maximum"` | no |
 | subnet | VPC Subnet ID the instance is launched in | `string` | n/a | yes |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
-| user\_data | Instance user data. Do not pass gzip-compressed data via this argument | `string` | `""` | no |
+| user\_data | The user data to provide when launching the instance. Do not pass gzip-compressed data via this argument; use `user_data_base64` instead | `string` | `null` | no |
+| user\_data\_base64 | Can be used instead of `user_data` to pass base64-encoded binary data directly. Use this instead of `user_data` whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption | `string` | `null` | no |
 | vpc\_id | The ID of the VPC that the instance security group belongs to | `string` | n/a | yes |
 | welcome\_message | Welcome message | `string` | `""` | no |
 
@@ -211,6 +212,7 @@ Available targets:
 |------|-------------|
 | additional\_eni\_ids | Map of ENI to EIP |
 | alarm | CloudWatch Alarm ID |
+| arn | ARN of the instance |
 | ebs\_ids | IDs of EBSs |
 | id | Disambiguated ID of the instance |
 | instance\_profile | Name of the instance's profile (either built or supplied) |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -71,7 +71,8 @@
 | statistic\_level | The statistic to apply to the alarm's associated metric. Allowed values are: SampleCount, Average, Sum, Minimum, Maximum | `string` | `"Maximum"` | no |
 | subnet | VPC Subnet ID the instance is launched in | `string` | n/a | yes |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
-| user\_data | Instance user data. Do not pass gzip-compressed data via this argument | `string` | `""` | no |
+| user\_data | The user data to provide when launching the instance. Do not pass gzip-compressed data via this argument; use `user_data_base64` instead | `string` | `null` | no |
+| user\_data\_base64 | Can be used instead of `user_data` to pass base64-encoded binary data directly. Use this instead of `user_data` whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption | `string` | `null` | no |
 | vpc\_id | The ID of the VPC that the instance security group belongs to | `string` | n/a | yes |
 | welcome\_message | Welcome message | `string` | `""` | no |
 
@@ -81,6 +82,7 @@
 |------|-------------|
 | additional\_eni\_ids | Map of ENI to EIP |
 | alarm | CloudWatch Alarm ID |
+| arn | ARN of the instance |
 | ebs\_ids | IDs of EBSs |
 | id | Disambiguated ID of the instance |
 | instance\_profile | Name of the instance's profile (either built or supplied) |

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -58,6 +58,11 @@ output "id" {
   value       = module.ec2_instance.id
 }
 
+output "arn" {
+  description = "ARN of the instance"
+  value       = module.ec2_instance.arn
+}
+
 output "name" {
   description = "Instance name"
   value       = module.ec2_instance.name

--- a/main.tf
+++ b/main.tf
@@ -97,6 +97,7 @@ resource "aws_instance" "default" {
   ebs_optimized               = var.ebs_optimized
   disable_api_termination     = var.disable_api_termination
   user_data                   = var.user_data
+  user_data_base64            = var.user_data_base64
   iam_instance_profile        = local.instance_profile
   associate_public_ip_address = var.associate_public_ip_address
   key_name                    = var.ssh_key_pair

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,6 +23,11 @@ output "id" {
   value       = join("", aws_instance.default.*.id)
 }
 
+output "arn" {
+  description = "ARN of the instance"
+  value       = join("", aws_instance.default.*.arn)
+}
+
 output "name" {
   description = "Instance name"
   value       = module.this.id

--- a/variables.tf
+++ b/variables.tf
@@ -17,8 +17,14 @@ variable "assign_eip_address" {
 
 variable "user_data" {
   type        = string
-  description = "Instance user data. Do not pass gzip-compressed data via this argument"
-  default     = ""
+  description = "The user data to provide when launching the instance. Do not pass gzip-compressed data via this argument; use `user_data_base64` instead"
+  default     = null
+}
+
+variable "user_data_base64" {
+  type        = string
+  description = "Can be used instead of `user_data` to pass base64-encoded binary data directly. Use this instead of `user_data` whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption"
+  default     = null
 }
 
 variable "instance_type" {


### PR DESCRIPTION
## what
* Add `user_data_base64` to inputs
* Add `arn` to outputs

## why
* `user_data_base64` can be used instead of `user_data` to pass base64-encoded binary data directly. Use this instead of user_data whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption

* Instance ARN is required for https://aws.amazon.com/backup/

