### PR TITLE
feat: add private eni provisioning

### DIFF
--- a/eni.tf
+++ b/eni.tf
@@ -33,7 +33,7 @@ resource "aws_eip" "additional" {
 
 
 resource "aws_network_interface" "additional_private" {
-  count     = var.additional_private_ips_count > 1 ? 1 : 0
+  count     = len(var.additional_ips_count) > 1 ? 1 : 0
   subnet_id = var.subnet
 
   private_ips_count = var.additional_private_ips_count

--- a/eni.tf
+++ b/eni.tf
@@ -33,7 +33,7 @@ resource "aws_eip" "additional" {
 
 
 resource "aws_network_interface" "additional_private" {
-  count     = length(var.additional_ips_count) > 1 ? 1 : 0
+  count     = length(var.additional_private_ips) > 0 ? 1 : 0
   subnet_id = var.subnet
 
   private_ips_count = var.additional_private_ips_count

--- a/eni.tf
+++ b/eni.tf
@@ -30,3 +30,23 @@ resource "aws_eip" "additional" {
   vpc               = true
   network_interface = aws_network_interface.additional[count.index].id
 }
+
+
+resource "aws_network_interface" "additional_private" {
+  count     = var.additional_private_ips_count > 1 ? 1 : 0
+  subnet_id = var.subnet
+
+  private_ips_count = var.additional_private_ips_count
+  private_ips       = var.additional_private_ips
+
+  security_groups = compact(
+    concat(
+      [
+        var.create_default_security_group ? join("", aws_security_group.default.*.id) : ""
+      ],
+      var.security_groups
+    )
+  )
+
+  tags = module.this.tags
+}

--- a/eni.tf
+++ b/eni.tf
@@ -33,7 +33,7 @@ resource "aws_eip" "additional" {
 
 
 resource "aws_network_interface" "additional_private" {
-  count     = len(var.additional_ips_count) > 1 ? 1 : 0
+  count     = length(var.additional_ips_count) > 1 ? 1 : 0
   subnet_id = var.subnet
 
   private_ips_count = var.additional_private_ips_count

--- a/outputs.tf
+++ b/outputs.tf
@@ -66,6 +66,11 @@ output "additional_eni_ids" {
   )
 }
 
+output "additional_private_eni_ids" {
+  description = "Map of ENI to EIP"
+  value = aws_network_interface.additional_private
+}
+
 output "ebs_ids" {
   description = "IDs of EBSs"
   value       = aws_ebs_volume.default.*.id

--- a/variables.tf
+++ b/variables.tf
@@ -247,6 +247,18 @@ variable "additional_ips_count" {
   default     = 0
 }
 
+variable "additional_private_ips_count" {
+  type        = number
+  description = "Count of additional private IPs"
+  default     = 0
+}
+
+variable "additional_private_ips" {
+  description = "List of private IPs to attach to the private ENI"
+  type        = list(string)
+  default     = []
+}
+
 variable "permissions_boundary_arn" {
   type        = string
   description = "Policy ARN to attach to instance role as a permissions boundary"


### PR DESCRIPTION
## what
*  This adds the possibility of creating private ENI, when you need some private IPs to be decoupled from the instance if it needs to be created and destroyed

## why
* The existing ENI creating always requires a public IP
* Additional ENIs are needed if the instance is to remain private


## references
* Why we need a count: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface#private_ips_count

