### PR TITLE
Add lifecycle block with ignore_changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -140,6 +140,10 @@ resource "aws_instance" "default" {
     http_tokens                 = var.metadata_http_tokens_required ? "required" : "optional"
   }
 
+  lifecycle {
+    ignore_changes = [user_data, user_data_base64]
+  }
+
   tags = module.this.tags
 }
 


### PR DESCRIPTION
## what
* Ignore changes to `user_data` or `user_data_base64`.

## why
* If you have a common `user_data` and periodically update policies it will try to recreate your ec2 instance without this lifecycle policy.

## references


