### PR TITLE
Fix for EBS volumes created when the instance has been disabled, plus some vars description improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Available targets:
 | <a name="input_additional_ips_count"></a> [additional\_ips\_count](#input\_additional\_ips\_count) | Count of additional EIPs | `number` | `0` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | <a name="input_ami"></a> [ami](#input\_ami) | The AMI to use for the instance. By default it is the AMI provided by Amazon with Ubuntu 16.04 | `string` | `""` | no |
-| <a name="input_ami_owner"></a> [ami\_owner](#input\_ami\_owner) | Owner of the given AMI (ignored if `ami` unset) | `string` | `""` | no |
+| <a name="input_ami_owner"></a> [ami\_owner](#input\_ami\_owner) | Owner of the given AMI (ignored if `ami` unset, required if set) | `string` | `""` | no |
 | <a name="input_applying_period"></a> [applying\_period](#input\_applying\_period) | The period in seconds over which the specified statistic is applied | `number` | `60` | no |
 | <a name="input_assign_eip_address"></a> [assign\_eip\_address](#input\_assign\_eip\_address) | Assign an Elastic IP address to the instance | `bool` | `true` | no |
 | <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | Associate a public IP address with the instance | `bool` | `false` | no |
@@ -267,9 +267,9 @@ Available targets:
 | <a name="input_ebs_iops"></a> [ebs\_iops](#input\_ebs\_iops) | Amount of provisioned IOPS. This must be set with a volume\_type of io1 | `number` | `0` | no |
 | <a name="input_ebs_optimized"></a> [ebs\_optimized](#input\_ebs\_optimized) | Launched EC2 instance will be EBS-optimized | `bool` | `false` | no |
 | <a name="input_ebs_volume_count"></a> [ebs\_volume\_count](#input\_ebs\_volume\_count) | Count of EBS volumes that will be attached to the instance | `number` | `0` | no |
-| <a name="input_ebs_volume_encrypted"></a> [ebs\_volume\_encrypted](#input\_ebs\_volume\_encrypted) | Size of the EBS volume in gigabytes | `bool` | `true` | no |
-| <a name="input_ebs_volume_size"></a> [ebs\_volume\_size](#input\_ebs\_volume\_size) | Size of the EBS volume in gigabytes | `number` | `10` | no |
-| <a name="input_ebs_volume_type"></a> [ebs\_volume\_type](#input\_ebs\_volume\_type) | The type of EBS volume. Can be standard, gp2 or io1 | `string` | `"gp2"` | no |
+| <a name="input_ebs_volume_encrypted"></a> [ebs\_volume\_encrypted](#input\_ebs\_volume\_encrypted) | Whether to encrypt the additional EBS volumes | `bool` | `true` | no |
+| <a name="input_ebs_volume_size"></a> [ebs\_volume\_size](#input\_ebs\_volume\_size) | Size of the additional EBS volumes in gigabytes | `number` | `10` | no |
+| <a name="input_ebs_volume_type"></a> [ebs\_volume\_type](#input\_ebs\_volume\_type) | The type of the additional EBS volumes. Can be standard, gp2 or io1 | `string` | `"gp2"` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_evaluation_periods"></a> [evaluation\_periods](#input\_evaluation\_periods) | The number of periods over which data is compared to the specified threshold. | `number` | `5` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -53,7 +53,7 @@
 | <a name="input_additional_ips_count"></a> [additional\_ips\_count](#input\_additional\_ips\_count) | Count of additional EIPs | `number` | `0` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | <a name="input_ami"></a> [ami](#input\_ami) | The AMI to use for the instance. By default it is the AMI provided by Amazon with Ubuntu 16.04 | `string` | `""` | no |
-| <a name="input_ami_owner"></a> [ami\_owner](#input\_ami\_owner) | Owner of the given AMI (ignored if `ami` unset) | `string` | `""` | no |
+| <a name="input_ami_owner"></a> [ami\_owner](#input\_ami\_owner) | Owner of the given AMI (ignored if `ami` unset, required if set) | `string` | `""` | no |
 | <a name="input_applying_period"></a> [applying\_period](#input\_applying\_period) | The period in seconds over which the specified statistic is applied | `number` | `60` | no |
 | <a name="input_assign_eip_address"></a> [assign\_eip\_address](#input\_assign\_eip\_address) | Assign an Elastic IP address to the instance | `bool` | `true` | no |
 | <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | Associate a public IP address with the instance | `bool` | `false` | no |
@@ -70,9 +70,9 @@
 | <a name="input_ebs_iops"></a> [ebs\_iops](#input\_ebs\_iops) | Amount of provisioned IOPS. This must be set with a volume\_type of io1 | `number` | `0` | no |
 | <a name="input_ebs_optimized"></a> [ebs\_optimized](#input\_ebs\_optimized) | Launched EC2 instance will be EBS-optimized | `bool` | `false` | no |
 | <a name="input_ebs_volume_count"></a> [ebs\_volume\_count](#input\_ebs\_volume\_count) | Count of EBS volumes that will be attached to the instance | `number` | `0` | no |
-| <a name="input_ebs_volume_encrypted"></a> [ebs\_volume\_encrypted](#input\_ebs\_volume\_encrypted) | Size of the EBS volume in gigabytes | `bool` | `true` | no |
-| <a name="input_ebs_volume_size"></a> [ebs\_volume\_size](#input\_ebs\_volume\_size) | Size of the EBS volume in gigabytes | `number` | `10` | no |
-| <a name="input_ebs_volume_type"></a> [ebs\_volume\_type](#input\_ebs\_volume\_type) | The type of EBS volume. Can be standard, gp2 or io1 | `string` | `"gp2"` | no |
+| <a name="input_ebs_volume_encrypted"></a> [ebs\_volume\_encrypted](#input\_ebs\_volume\_encrypted) | Whether to encrypt the additional EBS volumes | `bool` | `true` | no |
+| <a name="input_ebs_volume_size"></a> [ebs\_volume\_size](#input\_ebs\_volume\_size) | Size of the additional EBS volumes in gigabytes | `number` | `10` | no |
+| <a name="input_ebs_volume_type"></a> [ebs\_volume\_type](#input\_ebs\_volume\_type) | The type of the additional EBS volumes. Can be standard, gp2 or io1 | `string` | `"gp2"` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_evaluation_periods"></a> [evaluation\_periods](#input\_evaluation\_periods) | The number of periods over which data is compared to the specified threshold. | `number` | `5` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   instance_count = module.this.enabled ? 1 : 0
-  volume_count  = var.ebs_volume_count > 0 && local.instance_count > 0 ? var.ebs_volume_count : 0
+  volume_count   = var.ebs_volume_count > 0 && local.instance_count > 0 ? var.ebs_volume_count : 0
   # create an instance profile if the instance is enabled and we aren't given one to use
   instance_profile_count = module.this.enabled ? (length(var.instance_profile) > 0 ? 0 : 1) : 0
   instance_profile       = local.instance_profile_count == 0 ? var.instance_profile : join("", aws_iam_instance_profile.default.*.name)

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   instance_count = module.this.enabled ? 1 : 0
-  volumes_count  = var.ebs_volume_count != 0 && local.instance_count != 0 ? var.ebs_volume_count : 0
+  volumes_count  = var.ebs_volume_count > 0 && local.instance_count > 0 ? var.ebs_volume_count : 0
   # create an instance profile if the instance is enabled and we aren't given one to use
   instance_profile_count = module.this.enabled ? (length(var.instance_profile) > 0 ? 0 : 1) : 0
   instance_profile       = local.instance_profile_count == 0 ? var.instance_profile : join("", aws_iam_instance_profile.default.*.name)

--- a/main.tf
+++ b/main.tf
@@ -173,7 +173,7 @@ resource "aws_ebs_volume" "default" {
 }
 
 resource "aws_volume_attachment" "default" {
-  count       = local.volumes_count
+  count       = local.volume_count
   device_name = var.ebs_device_name[count.index]
   volume_id   = aws_ebs_volume.default.*.id[count.index]
   instance_id = join("", aws_instance.default.*.id)

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
-  instance_count         = module.this.enabled ? 1 : 0
-  volumes_count          = var.ebs_volume_count != 0 && local.instance_count != 0 ? var.ebs_volume_count : 0
+  instance_count = module.this.enabled ? 1 : 0
+  volumes_count  = var.ebs_volume_count != 0 && local.instance_count != 0 ? var.ebs_volume_count : 0
   # create an instance profile if the instance is enabled and we aren't given one to use
   instance_profile_count = module.this.enabled ? (length(var.instance_profile) > 0 ? 0 : 1) : 0
   instance_profile       = local.instance_profile_count == 0 ? var.instance_profile : join("", aws_iam_instance_profile.default.*.name)

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 locals {
-  instance_count = module.this.enabled ? 1 : 0
+  instance_count         = module.this.enabled ? 1 : 0
+  volumes_count          = var.ebs_volume_count != 0 && local.instance_count != 0 ? var.ebs_volume_count : 0
   # create an instance profile if the instance is enabled and we aren't given one to use
   instance_profile_count = module.this.enabled ? (length(var.instance_profile) > 0 ? 0 : 1) : 0
   instance_profile       = local.instance_profile_count == 0 ? var.instance_profile : join("", aws_iam_instance_profile.default.*.name)
@@ -161,7 +162,7 @@ resource "aws_eip" "default" {
 }
 
 resource "aws_ebs_volume" "default" {
-  count             = var.ebs_volume_count
+  count             = local.volumes_count
   availability_zone = local.availability_zone
   size              = var.ebs_volume_size
   iops              = local.ebs_iops
@@ -172,7 +173,7 @@ resource "aws_ebs_volume" "default" {
 }
 
 resource "aws_volume_attachment" "default" {
-  count       = var.ebs_volume_count
+  count       = local.volumes_count
   device_name = var.ebs_device_name[count.index]
   volume_id   = aws_ebs_volume.default.*.id[count.index]
   instance_id = join("", aws_instance.default.*.id)

--- a/main.tf
+++ b/main.tf
@@ -162,7 +162,7 @@ resource "aws_eip" "default" {
 }
 
 resource "aws_ebs_volume" "default" {
-  count             = local.volumes_count
+  count             = local.volume_count
   availability_zone = local.availability_zone
   size              = var.ebs_volume_size
   iops              = local.ebs_iops

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   instance_count = module.this.enabled ? 1 : 0
-  volumes_count  = var.ebs_volume_count > 0 && local.instance_count > 0 ? var.ebs_volume_count : 0
+  volume_count  = var.ebs_volume_count > 0 && local.instance_count > 0 ? var.ebs_volume_count : 0
   # create an instance profile if the instance is enabled and we aren't given one to use
   instance_profile_count = module.this.enabled ? (length(var.instance_profile) > 0 ? 0 : 1) : 0
   instance_profile       = local.instance_profile_count == 0 ? var.instance_profile : join("", aws_iam_instance_profile.default.*.name)

--- a/variables.tf
+++ b/variables.tf
@@ -87,7 +87,7 @@ variable "ami" {
 
 variable "ami_owner" {
   type        = string
-  description = "Owner of the given AMI (ignored if `ami` unset)"
+  description = "Owner of the given AMI (ignored if `ami` unset, required if set)"
   default     = ""
 }
 
@@ -159,19 +159,19 @@ variable "ebs_device_name" {
 
 variable "ebs_volume_type" {
   type        = string
-  description = "The type of EBS volume. Can be standard, gp2 or io1"
+  description = "The type of the additional EBS volumes. Can be standard, gp2 or io1"
   default     = "gp2"
 }
 
 variable "ebs_volume_size" {
   type        = number
-  description = "Size of the EBS volume in gigabytes"
+  description = "Size of the additional EBS volumes in gigabytes"
   default     = 10
 }
 
 variable "ebs_volume_encrypted" {
   type        = bool
-  description = "Size of the EBS volume in gigabytes"
+  description = "Whether to encrypt the additional EBS volumes"
   default     = true
 }
 


### PR DESCRIPTION
- Fixing #74 (EBS volumes will be created if enabled = false)
- Fixing a wrong description provided for ebs_volume_encrypted in variables.tf
- Changing some EBS related description to be clear those are "additional volumes"

## what
Adding a local variable and a `&&` to the creation of the EBS volumes we can avoid the creation of the additional volumes if the instance creation has been disabled.

## references
* Closes #74 

