### PR TITLE
Add user data replace feature

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Available targets:
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
 | <a name="input_user_data"></a> [user\_data](#input\_user\_data) | The user data to provide when launching the instance. Do not pass gzip-compressed data via this argument; use `user_data_base64` instead | `string` | `null` | no |
 | <a name="input_user_data_base64"></a> [user\_data\_base64](#input\_user\_data\_base64) | Can be used instead of `user_data` to pass base64-encoded binary data directly. Use this instead of `user_data` whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption | `string` | `null` | no |
+| <a name="input_user_data_replace_on_change"></a> [user\_data\_replace\_on\_change](#input\_user\_data\_replace\_on\_change) | When used in combination with `user_data` or `user_data_base64` will trigger a destroy and recreate when set to true. Defaults to false if not set. | `bool` | `false` | no |
 | <a name="input_volume_tags_enabled"></a> [volume\_tags\_enabled](#input\_volume\_tags\_enabled) | Whether or not to copy instance tags to root and EBS volumes | `bool` | `true` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC that the instance security group belongs to | `string` | n/a | yes |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -129,6 +129,7 @@
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
 | <a name="input_user_data"></a> [user\_data](#input\_user\_data) | The user data to provide when launching the instance. Do not pass gzip-compressed data via this argument; use `user_data_base64` instead | `string` | `null` | no |
 | <a name="input_user_data_base64"></a> [user\_data\_base64](#input\_user\_data\_base64) | Can be used instead of `user_data` to pass base64-encoded binary data directly. Use this instead of `user_data` whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption | `string` | `null` | no |
+| <a name="input_user_data_replace_on_change"></a> [user\_data\_replace\_on\_change](#input\_user\_data\_replace\_on\_change) | When used in combination with `user_data` or `user_data_base64` will trigger a destroy and recreate when set to true. Defaults to false if not set. | `bool` | `false` | no |
 | <a name="input_volume_tags_enabled"></a> [volume\_tags\_enabled](#input\_volume\_tags\_enabled) | Whether or not to copy instance tags to root and EBS volumes | `bool` | `true` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC that the instance security group belongs to | `string` | n/a | yes |
 

--- a/main.tf
+++ b/main.tf
@@ -117,6 +117,7 @@ resource "aws_instance" "default" {
   disable_api_termination              = var.disable_api_termination
   user_data                            = var.user_data
   user_data_base64                     = var.user_data_base64
+  user_data_replace_on_change          = var.user_data_replace_on_change
   iam_instance_profile                 = local.instance_profile
   instance_initiated_shutdown_behavior = var.instance_initiated_shutdown_behavior
   associate_public_ip_address          = var.associate_public_ip_address

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,12 @@ variable "user_data_base64" {
   default     = null
 }
 
+variable "user_data_replace_on_change" {
+  type        = bool
+  description = "When used in combination with `user_data` or `user_data_base64` will trigger a destroy and recreate when set to true. Defaults to false if not set."
+  default     = false
+}
+
 variable "instance_type" {
   type        = string
   description = "The type of the instance"


### PR DESCRIPTION
## what
* Allow flexibility to destroy and recreate ec2 instances when user data changes. See `user_data_replace_on_change` [option ](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#user_data_replace_on_change)
* Not sure if this is backwards compatible, I'm testing on `>=4.7.0` aws provider version.

## why
* Allow flexibility to destroy and recreate ec2 instances when user data changes. 

## references
* Fixes #132 

