### PR TITLE
Turn tenancy validation message into English prose

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -375,6 +375,6 @@ variable "tenancy" {
   description = "Tenancy of the instance (if the instance is running in a VPC). An instance with a tenancy of 'dedicated' runs on single-tenant hardware. The 'host' tenancy is not supported for the import-instance command. Valid values are 'default', 'dedicated', and 'host'."
   validation {
     condition     = contains(["default", "dedicated", "host"], lower(var.tenancy))
-    error_message = "Tenancy field can only be one of default, dedicated, host"
+    error_message = "Tenancy field can only be one of default, dedicated, host."
   }
 }


### PR DESCRIPTION
Adds a period at the end of the error message.

## what

A single character change to make this into English prose.

## why

```
╷
│ Error: Invalid validation error message
│ 
│   on .terraform/modules/instance/variables.tf line 378, in variable "tenancy":
│  378:     error_message = "Tenancy field can only be one of default, dedicated, host"
│ 
│ The validation error message must be at least one full sentence starting with an uppercase letter and ending with a period or question mark.
│ 
│ Your given message will be included as part of a larger Terraform error message, written as English prose. For broadly-shared modules we suggest using a similar writing style so that the overall result will be consistent.
╵
```

