### PR TITLE
Support AWS partition for SSM resources

### DIFF
--- a/ssm_patch.tf
+++ b/ssm_patch.tf
@@ -1,7 +1,7 @@
 
 locals {
   ssm_patch_log_bucket_enabled = local.ssm_enabled && var.ssm_patch_manager_s3_log_bucket != "" && var.ssm_patch_manager_s3_log_bucket != null
-  ssm_policy_arn               = var.ssm_patch_manager_iam_policy_arn == null || var.ssm_patch_manager_iam_policy_arn == "" ? "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore" : var.ssm_patch_manager_iam_policy_arn
+  ssm_policy_arn               = var.ssm_patch_manager_iam_policy_arn == null || var.ssm_patch_manager_iam_policy_arn == "" ? "arn:${data.aws_partition.default.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore" : var.ssm_patch_manager_iam_policy_arn
   ssm_enabled                  = local.enabled && var.ssm_patch_manager_enabled
 }
 
@@ -25,8 +25,8 @@ data "aws_iam_policy_document" "ssm_patch_s3_log_policy" {
       "s3:GetEncryptionConfiguration",
     ]
     resources = [
-      "arn:aws:s3:::${var.ssm_patch_manager_s3_log_bucket}/*",
-      "arn:aws:s3:::${var.ssm_patch_manager_s3_log_bucket}",
+      "arn:${data.aws_partition.default.partition}:s3:::${var.ssm_patch_manager_s3_log_bucket}/*",
+      "arn:${data.aws_partition.default.partition}:s3:::${var.ssm_patch_manager_s3_log_bucket}",
     ]
   }
 }


### PR DESCRIPTION
## what
* SSM patch is currently hardcoded to `aws` so this doesn't work when trying to use the role with AWS GovCloud.

## why
* This allows the role to work in with AWS GovCloud

## references
* The cloudwatch-alarm supports the AWS GovCloud partition

