### PR TITLE
Only get data.aws_ami.info if it's actually required

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ locals {
   availability_zone      = var.availability_zone != "" ? var.availability_zone : data.aws_subnet.default.availability_zone
   ami                    = var.ami != "" ? var.ami : join("", data.aws_ami.default.*.image_id)
   ami_owner              = var.ami != "" ? var.ami_owner : join("", data.aws_ami.default.*.owner_id)
-  root_volume_type       = var.root_volume_type != "" ? var.root_volume_type : data.aws_ami.info.root_device_type
+  root_volume_type       = var.root_volume_type != "" ? var.root_volume_type : one(data.aws_ami.info[*].root_device_type)
 
   region_domain  = local.region == "us-east-1" ? "compute-1.amazonaws.com" : "${local.region}.compute.amazonaws.com"
   eip_public_dns = "ec2-${replace(join("", aws_eip.default.*.public_ip), ".", "-")}.${local.region_domain}"
@@ -71,6 +71,8 @@ data "aws_ami" "default" {
 }
 
 data "aws_ami" "info" {
+  count = var.root_volume_type != "" ? 0 : 1
+
   filter {
     name   = "image-id"
     values = [local.ami]


### PR DESCRIPTION
## what

* Use data.aws_ami.info only if it's actually required

## why

* Fix Your query returned no results" error once the AMI ID is not listed within AWS marketplace

## references

* closes #150
* closes #143

