### PR TITLE
Correct how the volume_id is selected - Fix #165

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -191,6 +191,6 @@ resource "aws_ebs_volume" "default" {
 resource "aws_volume_attachment" "default" {
   count       = local.volume_count
   device_name = var.ebs_device_name[count.index]
-  volume_id   = one(aws_ebs_volume.default[*].id[count.index])
+  volume_id   = aws_ebs_volume.default[count.index].id
   instance_id = one(aws_instance.default[*].id)
 }


### PR DESCRIPTION
## what

Fix #165 - allows create an EC2 instance with additional volumes.

## why

The issue was introduced [here](https://github.com/cloudposse/terraform-aws-ec2-instance/commit/f7457a52dcb227ca6c4507bf9b3b0a31429a651e?diff=unified#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR194).

The `one` Terraform function returns an error, that blocks creating EC2 instances with additional (non-root) volumes.

## references

- [The one Terraform function docs](https://developer.hashicorp.com/terraform/language/functions/one)

closes #165 
