### PR TITLE
fix: Make able apply module in one run when aws_iam_instance_profile created in the same state

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ data "aws_ami" "info" {
 }
 
 data "aws_iam_instance_profile" "given" {
-  count = local.enabled && var.instance_profile_enabled && var.instance_profile != "" ? 1 : 0
+  count = local.enabled && var.instance_profile_enabled && var.instance_profile != "" && !var.instance_profile_created_at_the_same_run ? 1 : 0
   name  = var.instance_profile
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -50,12 +50,12 @@ output "security_group_ids" {
 
 output "role" {
   description = "Name of AWS IAM Role associated with the instance"
-  value       = local.instance_profile_count > 0 ? one(aws_iam_role.default[*].name) : (var.instance_profile_enabled ? one(data.aws_iam_instance_profile.given[*].role_name) : one([""]))
+  value       = local.instance_profile_count > 0 ? one(aws_iam_role.default[*].name) : (var.instance_profile_enabled && !var.instance_profile_created_at_the_same_run ? one(data.aws_iam_instance_profile.given[*].role_name) : one([""]))
 }
 
 output "role_arn" {
   description = "ARN of AWS IAM Role associated with the instance"
-  value       = local.instance_profile_count > 0 ? one(aws_iam_role.default[*].arn) : (var.instance_profile_enabled ? one(data.aws_iam_instance_profile.given[*].role_arn) : one([""]))
+  value       = local.instance_profile_count > 0 ? one(aws_iam_role.default[*].arn) : (var.instance_profile_enabled && !var.instance_profile_created_at_the_same_run ? one(data.aws_iam_instance_profile.given[*].role_arn) : one([""]))
 }
 
 output "alarm" {

--- a/variables.tf
+++ b/variables.tf
@@ -331,6 +331,13 @@ variable "instance_profile_enabled" {
   description = "Whether an IAM instance profile is created to pass a role to an Amazon EC2 instance when the instance starts"
 }
 
+
+variable "instance_profile_created_at_the_same_run" {
+  type = bool
+  default = false
+  description = "Whether the instance profile is created at the same terraform apply"
+}
+
 variable "instance_initiated_shutdown_behavior" {
   type        = string
   description = "Specifies whether an instance stops or terminates when you initiate shutdown from the instance. Can be one of 'stop' or 'terminate'."


### PR DESCRIPTION
## what

Bypassing call to `data "aws_iam_instance_profile" "given"`.

Prevent module fails here:
https://github.com/cloudposse/terraform-aws-ec2-instance/blob/596216fbdec0f1a9246c24cf1bd51e23e5734a15/main.tf#L84-L87

when you run `terraform plan` and when you create an instance profile in the same root module

```tf
resource "aws_iam_instance_profile" "default" {
  count = module.this.enabled ? 1 : 0
  name  = module.this.id
  role  = aws_iam_role.default[0].name
}

module "mongodb_ec2" {
  source  = "cloudposse/ec2-instance/aws"
  version = "1.2.1"

  instance_profile = aws_iam_instance_profile.default[0].name
  ...
```
## why

Currently, you need to create IAM somewhere else or in 2 applies, otherwise you'' face next error: 

![325991566-fab9934f-c4a3-411a-8a18-dd0cb5aa2830](https://github.com/cloudposse/terraform-aws-ec2-instance/assets/11096782/a0aeb856-4848-4b9c-a787-8c3b14c19b00)



P.S. I don't get how to run `terraform-docs` in this repo, so some additional polishing could be needed.
Plus var name probably could be better