### PR TITLE
fix: ignore changes to associate_public_ip_address

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -168,7 +168,8 @@ resource "aws_instance" "default" {
 
   lifecycle {
     ignore_changes = [
-      ami
+      ami,
+      associate_public_ip_address,
     ]
   }
 


### PR DESCRIPTION
## what

Add lifecycle ignore changes to `aws_instance.associate_public_ip_address`

## why

- prevent replacement on external aws eip association
