### PR TITLE
feat(aws_instance): add ignore_ami_changes option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -171,6 +171,10 @@ resource "aws_instance" "default" {
   tags = module.this.tags
 
   volume_tags = var.volume_tags_enabled ? module.this.tags : {}
+
+  lifecycle {
+    ignore_changes = var.ignore_ami_changes ? [ami] : []
+  }
 }
 
 resource "aws_eip" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -123,6 +123,12 @@ variable "ami_owner" {
   default     = ""
 }
 
+variable "ignore_ami_changes" {
+  type        = bool
+  description = "Do not recreate the EC2 instance if proivided AMI image ID changes"
+  default     = false
+}
+
 variable "ebs_optimized" {
   type        = bool
   description = "Launched EC2 instance will be EBS-optimized"


### PR DESCRIPTION
## what

Allow ignoring AMI image ID changes. EC2 instance won't be recreated If the AMI image id is provided from a data source changes.

## why

We use an aws_ami data Blocks that always provides the most recent version of selected image but that will cause the EC2 to recreate if the image is updated. We want to be able to upgrade only when we see fit.
