### PR TITLE
fix: allow stopping instance before detachment and/or forced ebs detachments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -193,8 +193,10 @@ resource "aws_ebs_volume" "default" {
 }
 
 resource "aws_volume_attachment" "default" {
-  count       = local.volume_count
-  device_name = var.ebs_device_name[count.index]
-  volume_id   = aws_ebs_volume.default[count.index].id
-  instance_id = one(aws_instance.default[*].id)
+  count                          = local.volume_count
+  device_name                    = var.ebs_device_name[count.index]
+  volume_id                      = aws_ebs_volume.default[count.index].id
+  instance_id                    = one(aws_instance.default[*].id)
+  force_detach                   = var.force_detach_ebs
+  stop_instance_before_detaching = var.stop_ec2_before_detaching_vol
 }

--- a/variables.tf
+++ b/variables.tf
@@ -435,3 +435,15 @@ variable "external_network_interfaces" {
   description = "The external interface definitions to attach to the instances. This depends on the instance type"
   default     = null
 }
+
+variable "force_detach_ebs" {
+  type        = bool
+  default     = false
+  description = "force the volume/s to detach from the instance."
+}
+
+variable "stop_ec2_before_detaching_vol" {
+  type        = bool
+  default     = false
+  description = "Set this to true to ensure that the target instance is stopped before trying to detach the volume/s."
+}


### PR DESCRIPTION
Added support to the EBS volume attachment resource for the `force_detach` and `stop_instance_before_detaching` arguments.

These changes allow users to:
     - Force the detachment of EBS volumes.
     - Stop instances before detaching volumes, ensuring smooth resource teardown during Terraform destroy operations.

## why

I cannot delete my Terraform resources using a standard Terraform destroy because I have attached additional ebs volumes to my instance and then ran disk configuration changes in my instance, for example, combined multiple ebs volumes into a striped disk config.

Business use cases may require additional EBS volumes, along with specific disk configurations for the volumes attached to EC2 instances.

When attempting to delete resources via Terraform, the destroy process fails due to issues with EBS volume attachments. These issues include timeouts or the inability to delete volumes because they are in a "busy" state.

The problem arises because Terraform attempts to detach EBS volumes before deleting/stopping the EC2 instance, leading to failures if the volume cannot be detached.

To address this, Terraform introduced the `force_detach` and `stop_instance_before_detaching` arguments, which allows forced detachment and/or stopping of the instance prior to detaching volumes. These enhancements mitigate the destroy-time failures and ensure smoother resource cleanup.

## references

The `force_detach` and `stop_instance_before_detaching` arguments were introduced in Terraform AWS provider version [v3.62.0](https://github.com/hashicorp/terraform-provider-aws/blob/v3.62.0/CHANGELOG.md).

Additional details and discussion about this issue can be found in this [GitHub thread](https://github.com/hashicorp/terraform-provider-aws/issues/4770).

